### PR TITLE
fix: correct cmake typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
 endif()
 
 # glob src
-file(GLOB_RECURSE SRC_FILES src/*.cpp)
+file(GLOB_RECURSE DD_TARGET_FILES src/*.cpp)
 
 # tests
 if(BUILD_TESTS)
@@ -39,5 +39,5 @@ if(BUILD_TESTS)
 endif()
 
 # lib
-add_library(${PROJECT_NAME} ${SRC_FILES})
+add_library(${PROJECT_NAME} ${DD_TARGET_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC include)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,20 +31,19 @@ file(GLOB_RECURSE TEST_SOURCES
         ${CMAKE_SOURCE_DIR}/tests/test_*.cpp)
 
 set(DD_SOURCES
-        ${DD_FILES})
+        ${DD_TARGET_FILES})
 
 # remove main.cpp from the list of sources
 list(REMOVE_ITEM DD_SOURCES ${CMAKE_SOURCE_DIR}/src/main.cpp)
 
 add_executable(${PROJECT_NAME}
         ${TEST_SOURCES}
-        ${DISPLAY_DEVICE_SOURCES})
+        ${DD_SOURCES})
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)
 target_link_libraries(${PROJECT_NAME}
         ${DD_EXTERNAL_LIBRARIES}
         gtest
-        gtest_main  # if we use this we don't need our own main function
-        ${PLATFORM_LIBRARIES})
+        gtest_main)  # if we use this we don't need our own main function
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${DD_DEFINITIONS} ${TEST_DEFINITIONS})
 target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${DD_COMPILE_OPTIONS}> -std=c++17)
 target_link_options(${PROJECT_NAME} PRIVATE)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix small typo in `tests/CMakeLists.txt`. Doesn't make any difference right now as `DD_SOURCES` is not yet populated in the main `CMakeLists.txt`


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
