### PR TITLE
fix: downgrade to gcc 11

### DIFF
--- a/.codeql-prebuild-cpp-Linux.sh
+++ b/.codeql-prebuild-cpp-Linux.sh
@@ -1,7 +1,7 @@
 # install dependencies for C++ analysis
 set -e
 
-gcc_version=13
+gcc_version=11
 
 sudo apt-get update -y
 

--- a/.codeql-prebuild-cpp-macOS.sh
+++ b/.codeql-prebuild-cpp-macOS.sh
@@ -1,7 +1,7 @@
 # install dependencies for C++ analysis
 set -e
 
-gcc_version=13
+gcc_version=11
 
 # install dependencies
 brew install \

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -3,6 +3,7 @@
 
 // system includes
 #include <chrono>
+#include <iomanip>
 #include <iostream>
 #include <mutex>
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -68,15 +68,6 @@ namespace display_device {
         }
       }
 
-      // // we need to ensure that the time formatter does not print decimal numbers for seconds as
-      // // it currently has inconsistent formatting logic between platforms...
-      // // Instead we will do it manually.
-      // std::time_t time { std::chrono::system_clock::to_time_t(now) };
-      // // const auto now_local_seconds { std::chrono::local_seconds(now_s) };
-      // // const auto now_decimal_part { now_ms - now_s };
-
-      // stream << std::put_time(std::localtime(&time), "%Y-%m-%d %H:%M:%S");
-
       // Log level
       switch (log_level) {
         case log_level_e::verbose:


### PR DESCRIPTION
## Description

Remove the usage of `std::format` to reduce GCC to V11.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
