### PR TITLE
build(codeql): fix gcc path for macOS

### DIFF
--- a/.codeql-prebuild-cpp-macOS.sh
+++ b/.codeql-prebuild-cpp-macOS.sh
@@ -12,8 +12,8 @@ brew install \
 mkdir -p build
 cd build || exit 1
 cmake \
-  -DCMAKE_C_COMPILER="/usr/local/bin/gcc-${gcc_version}" \
-  -DCMAKE_CXX_COMPILER="/usr/local/bin/g++-${gcc_version}" \
+  -DCMAKE_C_COMPILER="/opt/homebrew/bin/gcc-${gcc_version}" \
+  -DCMAKE_CXX_COMPILER="/opt/homebrew/bin/g++-${gcc_version}" \
   -G "Unix Makefiles" ..
 make -j"$(sysctl -n hw.logicalcpu)"
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
macOS-14 runner is arm64 and therefore homebrew installs packages to a different location.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
