### PR TITLE
ci: upload coverage in separate job matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,17 +167,46 @@ jobs:
             --xml-pretty \
             -o coverage.xml
 
-      - name: Upload coverage
-        # any except canceled or skipped
+      - name: Upload coverage artifact
         if: >-
           always() &&
-          (steps.test_report.outcome == 'success') &&
-          startsWith(github.repository, 'LizardByte/')
+          (steps.test_report.outcome == 'success')
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}
+          path: build/coverage.xml
+
+  coverage:
+    if: >-
+      always() &&
+      (needs.build.result == 'success' || needs.build.result == 'failure') &&
+      startsWith(github.repository, 'LizardByte/')
+    name: Coverage-${{ matrix.flag }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build_os: ubuntu-latest
+            flag: Linux
+          - build_os: macos-latest
+            flag: macOS
+          - build_os: windows-latest
+            flag: Windows
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-${{ matrix.build_os }}
+          path: build
+
+      - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:
           disable_search: true
           fail_ci_if_error: true
           files: ./build/coverage.xml
-          flags: ${{ runner.os }}
+          flags: ${{ matrix.flag }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Attempt to improve re-running failed coverage uploads, by not having to re-build/test the whole project.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
