### PR TITLE
feat: migrate CI (win) to UCRT64 and use debug build for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,13 @@ jobs:
         if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
+          msystem: ucrt64
           update: true
           install: >-
-            base-devel
-            make
-            mingw-w64-x86_64-binutils
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-binutils
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-toolchain
 
       - name: Prepare tests
         id: prepare-tests
@@ -142,7 +141,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake -G Ninja ..
+          cmake -DCMAKE_BUILD_TYPE:STRING=Debug -G Ninja ..
           ninja
 
       - name: Run tests

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Windows
 Requirements
 ~~~~~~~~~~~~
 
-First you need to install `MSYS2 <https://www.msys2.org>`__, then startup "MSYS2 MinGW 64-bit" and execute the following
+First you need to install `MSYS2 <https://www.msys2.org>`__, then startup "MSYS2 UCRT64" and execute the following
 codes.
 
 Update all packages:
@@ -52,13 +52,10 @@ Install dependencies:
    .. code-block:: bash
 
       pacman -S \
-        base-devel \
-        cmake \
-        gcc \
-        make \
-        mingw-w64-x86_64-binutils \
-        mingw-w64-x86_64-cmake \
-        mingw-w64-x86_64-toolchain
+        mingw-w64-ucrt-x86_64-binutils \
+        mingw-w64-ucrt-x86_64-cmake \
+        mingw-w64-ucrt-x86_64-ninja \
+        mingw-w64-ucrt-x86_64-toolchain
 
 Build
 ~~~~~
@@ -67,8 +64,8 @@ Build
 
 .. code-block:: bash
 
-   cmake -G "MinGW Makefiles" ..
-   mingw32-make -j$(nproc)
+   cmake -DCMAKE_BUILD_TYPE:STRING=Debug -G Ninja ..
+   ninja
 
 Test
 ~~~~


### PR DESCRIPTION
## Description
Migrate CI (win) to UCRT64 and use debug build for coverage

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
