### PR TITLE
feat: port more win utils

### DIFF
--- a/src/common/include/displaydevice/types.h
+++ b/src/common/include/displaydevice/types.h
@@ -10,7 +10,7 @@ namespace display_device {
   };
 
   /**
-   * @brief Floating point is stored in a "numerator/denominator" form.
+   * @brief Floating point stored in a "numerator/denominator" form.
    */
   struct Rational {
     unsigned int m_numerator;

--- a/src/common/include/displaydevice/types.h
+++ b/src/common/include/displaydevice/types.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace display_device {
+  /**
+   * @brief Display's resolution.
+   */
+  struct Resolution {
+    unsigned int m_width;
+    unsigned int m_height;
+  };
+
+  /**
+   * @brief Floating point is stored in a "numerator/denominator" form.
+   */
+  struct Rational {
+    unsigned int m_numerator;
+    unsigned int m_denominator;
+  };
+}  // namespace display_device

--- a/src/windows/include/displaydevice/windows/types.h
+++ b/src/windows/include/displaydevice/windows/types.h
@@ -9,6 +9,9 @@
 #include <string>
 #include <vector>
 
+// local includes
+#include "displaydevice/types.h"
+
 namespace display_device {
   /**
    * @brief Type of query the OS should perform while searching for display devices.
@@ -24,6 +27,14 @@ namespace display_device {
   struct PathAndModeData {
     std::vector<DISPLAYCONFIG_PATH_INFO> m_paths; /**< Available display paths. */
     std::vector<DISPLAYCONFIG_MODE_INFO> m_modes; /**< Display modes for ACTIVE displays. */
+  };
+
+  /**
+   * @brief Specifies additional constraints for the validated device.
+   */
+  enum class ValidatedPathType {
+    Active, /**< The device path must be active. */
+    Any /**< The device path can be active or inactive. */
   };
 
   /**
@@ -66,5 +77,13 @@ namespace display_device {
    * @note On Windows the order does not matter of both device ids or the inner lists.
    */
   using ActiveTopology = std::vector<std::vector<std::string>>;
+
+  /**
+   * @brief Display's mode (resolution + refresh rate).
+   */
+  struct DisplayMode {
+    Resolution m_resolution;
+    Rational m_refresh_rate;
+  };
 
 }  // namespace display_device

--- a/src/windows/windisplaydevicetopology.cpp
+++ b/src/windows/windisplaydevicetopology.cpp
@@ -69,7 +69,7 @@ namespace display_device {
     std::unordered_map<std::string, std::size_t> position_to_topology_index;
     ActiveTopology topology;
     for (const auto &path : display_data->m_paths) {
-      const auto device_info { win_utils::getDeviceInfoForValidPath(*m_w_api, path, true) };
+      const auto device_info { win_utils::getDeviceInfoForValidPath(*m_w_api, path, display_device::ValidatedPathType::Active) };
       if (!device_info) {
         continue;
       }

--- a/tests/unit/windows/utils/mockwinapilayer.cpp
+++ b/tests/unit/windows/utils/mockwinapilayer.cpp
@@ -68,7 +68,7 @@ namespace {
       data.m_modes.push_back({});
       data.m_modes.back().infoType = DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE;
       data.m_modes.back().sourceMode = {};  // Set the union
-      data.m_modes.back().sourceMode.position = { 3842, 0 };
+      data.m_modes.back().sourceMode.position = { 0, 1081 };
       data.m_modes.back().sourceMode.width = 1920;
       data.m_modes.back().sourceMode.height = 1080;
     }


### PR DESCRIPTION
## Description
Ported more utils before moving to the display mode stuff.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
