### PR TITLE
feat: add methods for handling primary displays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,9 @@ jobs:
           Set-Location -Path usbmmidd_v2/usbmmidd_v2
           ./deviceinstaller64 install usbmmidd.inf usbmmidd
 
-          # create 3 virtual displays, using 4 can crash the runner
+          # create 2 virtual displays, using 3+ can crash the runner
           # see: https://github.com/LizardByte/libdisplaydevice/pull/36
-          for ($i = 1; $i -le 3; $i++) {
+          for ($i = 1; $i -le 2; $i++) {
             ./deviceinstaller64 enableidd 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,9 @@ jobs:
           Set-Location -Path usbmmidd_v2/usbmmidd_v2
           ./deviceinstaller64 install usbmmidd.inf usbmmidd
 
-          # create 2 virtual displays, using 4 can crash the runner
+          # create 3 virtual displays, using 4 can crash the runner
           # see: https://github.com/LizardByte/libdisplaydevice/pull/36
-          for ($i = 1; $i -le 2; $i++) {
+          for ($i = 1; $i -le 3; $i++) {
             ./deviceinstaller64 enableidd 1
           }
 

--- a/src/windows/include/displaydevice/windows/winapiutils.h
+++ b/src/windows/include/displaydevice/windows/winapiutils.h
@@ -62,6 +62,21 @@ namespace display_device::win_utils {
   setActive(DISPLAYCONFIG_PATH_INFO &path);
 
   /**
+   * @brief Check if the display's source mode is primary - if the associated device is a primary display device.
+   * @param mode Mode to check.
+   * @returns True if the mode's origin point is at (0, 0) coordinate (primary), false otherwise.
+   * @note It is possible to have multiple primary source modes at the same time.
+   *
+   * EXAMPLES:
+   * ```cpp
+   * DISPLAYCONFIG_SOURCE_MODE mode;
+   * const bool is_primary = isPrimary(mode);
+   * ```
+   */
+  bool
+  isPrimary(const DISPLAYCONFIG_SOURCE_MODE &mode);
+
+  /**
    * @brief Get the source mode index from the path.
    *
    * It performs sanity checks on the modes list that the index is indeed correct.

--- a/src/windows/include/displaydevice/windows/windisplaydevice.h
+++ b/src/windows/include/displaydevice/windows/windisplaydevice.h
@@ -43,6 +43,14 @@ namespace display_device {
     [[nodiscard]] bool
     setDisplayModes(const DeviceDisplayModeMap &modes) override;
 
+    /** For details @see WinDisplayDeviceInterface::isPrimary */
+    [[nodiscard]] bool
+    isPrimary(const std::string &device_id) const override;
+
+    /** For details @see WinDisplayDeviceInterface::setAsPrimary */
+    [[nodiscard]] bool
+    setAsPrimary(const std::string &device_id) override;
+
   private:
     std::shared_ptr<WinApiLayerInterface> m_w_api;
   };

--- a/src/windows/include/displaydevice/windows/windisplaydeviceinterface.h
+++ b/src/windows/include/displaydevice/windows/windisplaydeviceinterface.h
@@ -119,5 +119,36 @@ namespace display_device {
      */
     [[nodiscard]] virtual bool
     setDisplayModes(const DeviceDisplayModeMap &modes) = 0;
+
+    /**
+     * @brief Check whether the specified device is primary.
+     * @param device_id A device to perform the check for.
+     * @returns True if the device is primary, false otherwise.
+     *
+     * EXAMPLES:
+     * ```cpp
+     * const WinDisplayDeviceInterface* iface = getIface(...);
+     * const std::string device_id { "MY_DEVICE_ID" };
+     * const bool is_primary = iface->isPrimary(device_id);
+     * ```
+     */
+    [[nodiscard]] virtual bool
+    isPrimary(const std::string &device_id) const = 0;
+
+    /**
+     * @brief Set the device as a primary display.
+     * @param device_id A device to set as primary.
+     * @returns True if the device is or was set as primary, false otherwise.
+     * @note On Windows if the device is duplicated, the other duplicated device(-s) will also become a primary device.
+     *
+     * EXAMPLES:
+     * ```cpp
+     * const WinDisplayDeviceInterface* iface = getIface(...);
+     * const std::string device_id { "MY_DEVICE_ID" };
+     * const bool success = iface->set_as_primary_device(device_id);
+     * ```
+     */
+    [[nodiscard]] virtual bool
+    setAsPrimary(const std::string &device_id) = 0;
   };
 }  // namespace display_device

--- a/src/windows/winapiutils.cpp
+++ b/src/windows/winapiutils.cpp
@@ -76,6 +76,11 @@ namespace display_device::win_utils {
     path.flags |= DISPLAYCONFIG_PATH_ACTIVE;
   }
 
+  bool
+  isPrimary(const DISPLAYCONFIG_SOURCE_MODE &mode) {
+    return mode.position.x == 0 && mode.position.y == 0;
+  }
+
   std::optional<UINT32>
   getSourceIndex(const DISPLAYCONFIG_PATH_INFO &path, const std::vector<DISPLAYCONFIG_MODE_INFO> &modes) {
     // The MS docs is not clear when to access the index union struct or not. It appears that union struct is available,

--- a/src/windows/windisplaydeviceprimary.cpp
+++ b/src/windows/windisplaydeviceprimary.cpp
@@ -1,0 +1,107 @@
+// class header include
+#include "displaydevice/windows/windisplaydevice.h"
+
+// local includes
+#include "displaydevice/logging.h"
+#include "displaydevice/windows/winapiutils.h"
+
+namespace display_device {
+  bool
+  WinDisplayDevice::isPrimary(const std::string &device_id) const {
+    if (device_id.empty()) {
+      DD_LOG(error) << "Device id is empty!";
+      return false;
+    }
+
+    const auto display_data { m_w_api->queryDisplayConfig(QueryType::Active) };
+    if (!display_data) {
+      // Error already logged
+      return false;
+    }
+
+    const auto path { win_utils::getActivePath(*m_w_api, device_id, display_data->m_paths) };
+    if (!path) {
+      DD_LOG(error) << "Failed to find active device for " << device_id << "!";
+      return false;
+    }
+
+    const auto source_mode { win_utils::getSourceMode(win_utils::getSourceIndex(*path, display_data->m_modes), display_data->m_modes) };
+    if (!source_mode) {
+      DD_LOG(error) << "Active device does not have a source mode: " << device_id << "!";
+      return false;
+    }
+
+    return win_utils::isPrimary(*source_mode);
+  }
+
+  bool
+  WinDisplayDevice::setAsPrimary(const std::string &device_id) {
+    if (device_id.empty()) {
+      DD_LOG(error) << "Device id is empty!";
+      return false;
+    }
+
+    auto display_data { m_w_api->queryDisplayConfig(QueryType::Active) };
+    if (!display_data) {
+      // Error already logged
+      return false;
+    }
+
+    // Get the current origin point of the device (the one that we want to make primary)
+    POINTL origin;
+    {
+      const auto path { win_utils::getActivePath(*m_w_api, device_id, display_data->m_paths) };
+      if (!path) {
+        DD_LOG(error) << "Failed to find device for " << device_id << "!";
+        return false;
+      }
+
+      const auto source_mode { win_utils::getSourceMode(win_utils::getSourceIndex(*path, display_data->m_modes), display_data->m_modes) };
+      if (!source_mode) {
+        DD_LOG(error) << "Active device does not have a source mode: " << device_id << "!";
+        return false;
+      }
+
+      if (win_utils::isPrimary(*source_mode)) {
+        DD_LOG(debug) << "Device " << device_id << " is already a primary device.";
+        return true;
+      }
+
+      origin = source_mode->position;
+    }
+
+    // Shift the source mode origin points accordingly, so that the provided
+    // device moves to (0, 0) position and others to their new positions.
+    std::set<UINT32> modified_modes;
+    for (auto &path : display_data->m_paths) {
+      const auto current_id { m_w_api->getDeviceId(path) };
+      const auto source_index { win_utils::getSourceIndex(path, display_data->m_modes) };
+      auto source_mode { win_utils::getSourceMode(source_index, display_data->m_modes) };
+
+      if (!source_index || !source_mode) {
+        DD_LOG(error) << "Active device does not have a source mode: " << current_id << "!";
+        return false;
+      }
+
+      if (modified_modes.find(*source_index) != std::end(modified_modes)) {
+        // Happens when VIRTUAL_MODE_AWARE is not specified when querying paths, probably will never happen in our (since it's always set), but just to be safe...
+        DD_LOG(debug) << "Device " << current_id << " shares the same mode index as a previous device. Device is duplicated. Skipping.";
+        continue;
+      }
+
+      source_mode->position.x -= origin.x;
+      source_mode->position.y -= origin.y;
+
+      modified_modes.insert(*source_index);
+    }
+
+    const UINT32 flags { SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_SAVE_TO_DATABASE | SDC_VIRTUAL_MODE_AWARE };
+    const LONG result { m_w_api->setDisplayConfig(display_data->m_paths, display_data->m_modes, flags) };
+    if (result != ERROR_SUCCESS) {
+      DD_LOG(error) << m_w_api->getErrorString(result) << " failed to set primary mode for " << device_id << "!";
+      return false;
+    }
+
+    return true;
+  }
+}  // namespace display_device

--- a/tests/unit/windows/test_winapiutils.cpp
+++ b/tests/unit/windows/test_winapiutils.cpp
@@ -181,6 +181,20 @@ TEST_F_S_MOCKED(IsActiveAndSetActive) {
   EXPECT_EQ(display_device::win_utils::isActive(contains_active_path), true);
 }
 
+TEST_F_S_MOCKED(IsPrimary) {
+  DISPLAYCONFIG_SOURCE_MODE primary_mode;
+  DISPLAYCONFIG_SOURCE_MODE non_primary_mode_1;
+  DISPLAYCONFIG_SOURCE_MODE non_primary_mode_2;
+
+  primary_mode.position = { 0, 0 };
+  non_primary_mode_1.position = { 1, 0 };
+  non_primary_mode_2.position = { 0, 2 };
+
+  EXPECT_TRUE(display_device::win_utils::isPrimary(primary_mode));
+  EXPECT_FALSE(display_device::win_utils::isPrimary(non_primary_mode_1));
+  EXPECT_FALSE(display_device::win_utils::isPrimary(non_primary_mode_2));
+}
+
 TEST_F_S_MOCKED(GetSourceIndex) {
   DISPLAYCONFIG_PATH_INFO path;
   std::vector<DISPLAYCONFIG_MODE_INFO> modes;

--- a/tests/unit/windows/test_windisplaydevicemodes.cpp
+++ b/tests/unit/windows/test_windisplaydevicemodes.cpp
@@ -159,7 +159,7 @@ TEST_F_S(GetCurrentDisplayModes) {
 }
 
 TEST_F_S(SetCurrentDisplayModes, ExtendedTopology) {
-  const auto available_devices { getAvailableDevices(*m_layer, true) };
+  const auto available_devices { getAvailableDevices(*m_layer) };
   ASSERT_TRUE(available_devices);
 
   if (available_devices->size() < 2) {
@@ -184,7 +184,7 @@ TEST_F_S(SetCurrentDisplayModes, ExtendedTopology) {
 }
 
 TEST_F_S(SetCurrentDisplayModes, DuplicatedTopology) {
-  const auto available_devices { getAvailableDevices(*m_layer, true) };
+  const auto available_devices { getAvailableDevices(*m_layer) };
   ASSERT_TRUE(available_devices);
 
   if (available_devices->size() < 2) {
@@ -214,7 +214,7 @@ TEST_F_S(SetCurrentDisplayModes, DuplicatedTopology) {
 }
 
 TEST_F_S(SetCurrentDisplayModes, MixedTopology) {
-  const auto available_devices { getAvailableDevices(*m_layer, true) };
+  const auto available_devices { getAvailableDevices(*m_layer) };
   ASSERT_TRUE(available_devices);
 
   if (available_devices->size() < 3) {

--- a/tests/unit/windows/test_windisplaydeviceprimary.cpp
+++ b/tests/unit/windows/test_windisplaydeviceprimary.cpp
@@ -1,0 +1,376 @@
+// local includes
+#include "displaydevice/windows/winapilayer.h"
+#include "displaydevice/windows/winapiutils.h"
+#include "displaydevice/windows/windisplaydevice.h"
+#include "fixtures.h"
+#include "utils/comparison.h"
+#include "utils/guards.h"
+#include "utils/mockwinapilayer.h"
+
+namespace {
+  // Convenience keywords for GMock
+  using ::testing::_;
+  using ::testing::InSequence;
+  using ::testing::Return;
+  using ::testing::StrictMock;
+
+  // Test fixture(s) for this file
+  class WinDisplayDevicePrimary: public BaseTest {
+  public:
+    bool
+    isSystemTest() const override {
+      return true;
+    }
+
+    std::shared_ptr<display_device::WinApiLayer> m_layer { std::make_shared<display_device::WinApiLayer>() };
+    display_device::WinDisplayDevice m_win_dd { m_layer };
+  };
+
+  class WinDisplayDevicePrimaryMocked: public BaseTest {
+  public:
+    void
+    setupExpectedGetActivePathCall(int id_number, InSequence & /* To ensure that sequence is created outside this scope */) {
+      for (int i = 1; i <= id_number; ++i) {
+        EXPECT_CALL(*m_layer, getMonitorDevicePath(_))
+          .Times(1)
+          .WillOnce(Return("PathX"))
+          .RetiresOnSaturation();
+        EXPECT_CALL(*m_layer, getDeviceId(_))
+          .Times(1)
+          .WillOnce(Return("DeviceId" + std::to_string(i)))
+          .RetiresOnSaturation();
+        EXPECT_CALL(*m_layer, getDisplayName(_))
+          .Times(1)
+          .WillOnce(Return("DisplayNameX"))
+          .RetiresOnSaturation();
+      }
+    }
+
+    std::shared_ptr<StrictMock<display_device::MockWinApiLayer>> m_layer { std::make_shared<StrictMock<display_device::MockWinApiLayer>>() };
+    display_device::WinDisplayDevice m_win_dd { m_layer };
+  };
+
+  // Specialized TEST macro(s) for this test file
+#define TEST_F_S(...) DD_MAKE_TEST(TEST_F, WinDisplayDevicePrimary, __VA_ARGS__)
+#define TEST_F_S_MOCKED(...) DD_MAKE_TEST(TEST_F, WinDisplayDevicePrimaryMocked, __VA_ARGS__)
+
+  // Additional convenience global const(s)
+  const UINT32 FLAGS { SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_SAVE_TO_DATABASE | SDC_VIRTUAL_MODE_AWARE };
+
+  // Helper functions
+  void
+  shiftModeBy(std::optional<display_device::PathAndModeData> &pam, int path_index, POINTL point) {
+    auto &mode { pam->m_modes.at(pam->m_paths.at(path_index).sourceInfo.sourceModeInfoIdx) };
+    mode.sourceMode.position.x -= point.x;
+    mode.sourceMode.position.y -= point.y;
+  }
+}  // namespace
+
+TEST_F_S(IsPrimary) {
+  const auto flat_topology { flattenTopology(m_win_dd.getCurrentTopology()) };
+  EXPECT_TRUE(std::ranges::any_of(flat_topology, [&](auto device_id) { return m_win_dd.isPrimary(device_id); }));
+}
+
+TEST_F_S(SetAsPrimary, ExtendedTopology) {
+  const auto available_devices { getAvailableDevices(*m_layer) };
+  ASSERT_TRUE(available_devices);
+
+  if (available_devices->size() < 2) {
+    GTEST_SKIP_("Not enough devices are available in the system.");
+  }
+
+  const auto topology_guard { makeTopologyGuard(m_win_dd) };
+  ASSERT_TRUE(m_win_dd.setTopology({ { available_devices->at(0) }, { available_devices->at(1) } }));
+
+  const auto primary_guard { makePrimaryGuard(m_win_dd) };
+  ASSERT_TRUE(m_win_dd.setAsPrimary(available_devices->at(0)));
+  ASSERT_TRUE(m_win_dd.setAsPrimary(available_devices->at(1)));
+}
+
+TEST_F_S(SetAsPrimary, DuplicatedTopology) {
+  const auto available_devices { getAvailableDevices(*m_layer) };
+  ASSERT_TRUE(available_devices);
+
+  if (available_devices->size() < 2) {
+    GTEST_SKIP_("Not enough devices are available in the system.");
+  }
+
+  const auto topology_guard { makeTopologyGuard(m_win_dd) };
+  ASSERT_TRUE(m_win_dd.setTopology({ { available_devices->at(0), available_devices->at(1) } }));
+
+  const auto primary_guard { makePrimaryGuard(m_win_dd) };
+  ASSERT_TRUE(m_win_dd.setAsPrimary(available_devices->at(0)));
+  ASSERT_TRUE(m_win_dd.setAsPrimary(available_devices->at(1)));
+}
+
+TEST_F_S(SetAsPrimary, MixedTopology) {
+  const auto available_devices { getAvailableDevices(*m_layer) };
+  ASSERT_TRUE(available_devices);
+
+  if (available_devices->size() < 3) {
+    GTEST_SKIP_("Not enough devices are available in the system.");
+  }
+
+  const auto topology_guard { makeTopologyGuard(m_win_dd) };
+  ASSERT_TRUE(m_win_dd.setTopology({ { available_devices->at(0) }, { available_devices->at(1), available_devices->at(2) } }));
+
+  const auto primary_guard { makePrimaryGuard(m_win_dd) };
+  ASSERT_TRUE(m_win_dd.setAsPrimary(available_devices->at(0)));
+  ASSERT_TRUE(m_win_dd.setAsPrimary(available_devices->at(1)));
+  ASSERT_TRUE(m_win_dd.setAsPrimary(available_devices->at(2)));
+}
+
+TEST_F_S_MOCKED(IsPrimary, Valid, True) {
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES));
+  setupExpectedGetActivePathCall(1, sequence);
+
+  EXPECT_TRUE(m_win_dd.isPrimary("DeviceId1"));
+}
+
+TEST_F_S_MOCKED(IsPrimary, Valid, False) {
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES));
+  setupExpectedGetActivePathCall(1, sequence);
+  setupExpectedGetActivePathCall(2, sequence);
+
+  EXPECT_FALSE(m_win_dd.isPrimary("DeviceId2"));
+}
+
+TEST_F_S_MOCKED(IsPrimary, EmptyId) {
+  EXPECT_FALSE(m_win_dd.isPrimary(""));
+}
+
+TEST_F_S_MOCKED(IsPrimary, FailedToQueryDevices) {
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(ut_consts::PAM_NULL));
+
+  EXPECT_FALSE(m_win_dd.isPrimary("DeviceId1"));
+}
+
+TEST_F_S_MOCKED(IsPrimary, FailedToGetActivePath) {
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(ut_consts::PAM_EMPTY));
+
+  EXPECT_FALSE(m_win_dd.isPrimary("DeviceId1"));
+}
+
+TEST_F_S_MOCKED(IsPrimary, FailedToGetSourceMode) {
+  auto pam_no_modes { ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES };
+  pam_no_modes->m_modes.clear();
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(pam_no_modes));
+  setupExpectedGetActivePathCall(1, sequence);
+
+  EXPECT_FALSE(m_win_dd.isPrimary("DeviceId1"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, AlreadyPrimary) {
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES));
+  setupExpectedGetActivePathCall(1, sequence);
+
+  EXPECT_TRUE(m_win_dd.setAsPrimary("DeviceId1"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, DuplicatePrimaryDevicesSet) {
+  const auto initial_pam { ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES };
+
+  auto origin_point { initial_pam->m_modes.at(initial_pam->m_paths.at(1).sourceInfo.sourceModeInfoIdx).sourceMode.position };
+  auto expected_pam { initial_pam };
+  shiftModeBy(expected_pam, 0, origin_point);
+  shiftModeBy(expected_pam, 1, origin_point);
+  shiftModeBy(expected_pam, 2, origin_point);
+  shiftModeBy(expected_pam, 3, origin_point);
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(initial_pam));
+  setupExpectedGetActivePathCall(2, sequence);
+  for (int i = 1; i <= 4; ++i) {
+    EXPECT_CALL(*m_layer, getDeviceId(_))
+      .Times(1)
+      .WillOnce(Return("DeviceId" + std::to_string(i)))
+      .RetiresOnSaturation();
+  }
+
+  EXPECT_CALL(*m_layer, setDisplayConfig(expected_pam->m_paths, expected_pam->m_modes, FLAGS))
+    .Times(1)
+    .WillOnce(Return(ERROR_SUCCESS))
+    .RetiresOnSaturation();
+
+  EXPECT_TRUE(m_win_dd.setAsPrimary("DeviceId2"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, NonDuplicatePrimaryDeviceSet) {
+  const auto initial_pam { ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES };
+
+  auto origin_point { initial_pam->m_modes.at(initial_pam->m_paths.at(3).sourceInfo.sourceModeInfoIdx).sourceMode.position };
+  auto expected_pam { initial_pam };
+  shiftModeBy(expected_pam, 0, origin_point);
+  shiftModeBy(expected_pam, 1, origin_point);
+  shiftModeBy(expected_pam, 2, origin_point);
+  shiftModeBy(expected_pam, 3, origin_point);
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(initial_pam));
+  setupExpectedGetActivePathCall(4, sequence);
+  for (int i = 1; i <= 4; ++i) {
+    EXPECT_CALL(*m_layer, getDeviceId(_))
+      .Times(1)
+      .WillOnce(Return("DeviceId" + std::to_string(i)))
+      .RetiresOnSaturation();
+  }
+
+  EXPECT_CALL(*m_layer, setDisplayConfig(expected_pam->m_paths, expected_pam->m_modes, FLAGS))
+    .Times(1)
+    .WillOnce(Return(ERROR_SUCCESS))
+    .RetiresOnSaturation();
+
+  EXPECT_TRUE(m_win_dd.setAsPrimary("DeviceId4"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, SharedModeShiftedOnce) {
+  auto initial_pam { ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES };
+  initial_pam->m_paths.at(2).sourceInfo.sourceModeInfoIdx = initial_pam->m_paths.at(1).sourceInfo.sourceModeInfoIdx;
+
+  auto origin_point { initial_pam->m_modes.at(initial_pam->m_paths.at(1).sourceInfo.sourceModeInfoIdx).sourceMode.position };
+  auto expected_pam { initial_pam };
+  shiftModeBy(expected_pam, 0, origin_point);
+  shiftModeBy(expected_pam, 1, origin_point);
+  shiftModeBy(expected_pam, 3, origin_point);
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(initial_pam));
+  setupExpectedGetActivePathCall(2, sequence);
+  for (int i = 1; i <= 4; ++i) {
+    EXPECT_CALL(*m_layer, getDeviceId(_))
+      .Times(1)
+      .WillOnce(Return("DeviceId" + std::to_string(i)))
+      .RetiresOnSaturation();
+  }
+
+  EXPECT_CALL(*m_layer, setDisplayConfig(expected_pam->m_paths, expected_pam->m_modes, FLAGS))
+    .Times(1)
+    .WillOnce(Return(ERROR_SUCCESS))
+    .RetiresOnSaturation();
+
+  EXPECT_TRUE(m_win_dd.setAsPrimary("DeviceId2"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, EmptyId) {
+  EXPECT_FALSE(m_win_dd.setAsPrimary(""));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, FailedToQueryDevices) {
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(ut_consts::PAM_NULL));
+
+  EXPECT_FALSE(m_win_dd.setAsPrimary("DeviceId1"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, FailedToGetActivePath) {
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(ut_consts::PAM_EMPTY));
+
+  EXPECT_FALSE(m_win_dd.setAsPrimary("DeviceId1"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, FailedToGetSourceMode) {
+  auto pam_no_modes { ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES };
+  pam_no_modes->m_modes.clear();
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(pam_no_modes));
+  setupExpectedGetActivePathCall(1, sequence);
+
+  EXPECT_FALSE(m_win_dd.setAsPrimary("DeviceId1"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, FailedToGetSourceIndex, DuringShift) {
+  auto pam_invalid_mode_idx { ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES };
+  display_device::win_utils::setSourceIndex(pam_invalid_mode_idx->m_paths.at(0), std::nullopt);
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(pam_invalid_mode_idx));
+  setupExpectedGetActivePathCall(2, sequence);
+  EXPECT_CALL(*m_layer, getDeviceId(_))
+    .Times(1)
+    .WillOnce(Return("DeviceId1"))
+    .RetiresOnSaturation();
+
+  EXPECT_FALSE(m_win_dd.setAsPrimary("DeviceId2"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, FailedToGetSourceMode, DuringShift) {
+  auto pam_invalid_mode_type { ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES };
+  pam_invalid_mode_type->m_modes.at(pam_invalid_mode_type->m_paths.at(0).sourceInfo.sourceModeInfoIdx).infoType = DISPLAYCONFIG_MODE_INFO_TYPE_TARGET;
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(pam_invalid_mode_type));
+  setupExpectedGetActivePathCall(2, sequence);
+  EXPECT_CALL(*m_layer, getDeviceId(_))
+    .Times(1)
+    .WillOnce(Return("DeviceId1"))
+    .RetiresOnSaturation();
+
+  EXPECT_FALSE(m_win_dd.setAsPrimary("DeviceId2"));
+}
+
+TEST_F_S_MOCKED(SetAsPrimary, FailedToSetDisplayConfig) {
+  const auto initial_pam { ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES };
+
+  auto origin_point { initial_pam->m_modes.at(initial_pam->m_paths.at(3).sourceInfo.sourceModeInfoIdx).sourceMode.position };
+  auto expected_pam { initial_pam };
+  shiftModeBy(expected_pam, 0, origin_point);
+  shiftModeBy(expected_pam, 1, origin_point);
+  shiftModeBy(expected_pam, 2, origin_point);
+  shiftModeBy(expected_pam, 3, origin_point);
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(initial_pam));
+  setupExpectedGetActivePathCall(4, sequence);
+  for (int i = 1; i <= 4; ++i) {
+    EXPECT_CALL(*m_layer, getDeviceId(_))
+      .Times(1)
+      .WillOnce(Return("DeviceId" + std::to_string(i)))
+      .RetiresOnSaturation();
+  }
+
+  EXPECT_CALL(*m_layer, setDisplayConfig(expected_pam->m_paths, expected_pam->m_modes, FLAGS))
+    .Times(1)
+    .WillOnce(Return(ERROR_ACCESS_DENIED))
+    .RetiresOnSaturation();
+  EXPECT_CALL(*m_layer, getErrorString(ERROR_ACCESS_DENIED))
+    .Times(1)
+    .WillRepeatedly(Return("ErrorDesc"))
+    .RetiresOnSaturation();
+
+  EXPECT_FALSE(m_win_dd.setAsPrimary("DeviceId4"));
+}

--- a/tests/unit/windows/test_windisplaydevicetopology.cpp
+++ b/tests/unit/windows/test_windisplaydevicetopology.cpp
@@ -94,7 +94,7 @@ TEST_F_S(GetCurrentTopology) {
 }
 
 TEST_F_S(SetCurrentTopology, ExtendedTopology) {
-  const auto available_devices { getAvailableDevices(*m_layer) };
+  const auto available_devices { getAvailableDevices(*m_layer, false) };
   ASSERT_TRUE(available_devices);
 
   if (available_devices->size() < 2) {
@@ -116,7 +116,7 @@ TEST_F_S(SetCurrentTopology, ExtendedTopology) {
 }
 
 TEST_F_S(SetCurrentTopology, DuplicatedTopology) {
-  const auto available_devices { getAvailableDevices(*m_layer) };
+  const auto available_devices { getAvailableDevices(*m_layer, false) };
   ASSERT_TRUE(available_devices);
 
   if (available_devices->size() < 2) {
@@ -134,7 +134,7 @@ TEST_F_S(SetCurrentTopology, DuplicatedTopology) {
 }
 
 TEST_F_S(SetCurrentTopology, MixedTopology) {
-  const auto available_devices { getAvailableDevices(*m_layer) };
+  const auto available_devices { getAvailableDevices(*m_layer, false) };
   ASSERT_TRUE(available_devices);
 
   if (available_devices->size() < 3) {

--- a/tests/unit/windows/utils/guards.h
+++ b/tests/unit/windows/utils/guards.h
@@ -21,3 +21,19 @@ makeModeGuard(display_device::WinDisplayDevice &win_dd) {
     static_cast<void>(win_dd.setDisplayModes(modes));
   });
 }
+
+inline auto
+makePrimaryGuard(display_device::WinDisplayDevice &win_dd) {
+  return boost::scope::make_scope_exit([&win_dd, primary_device = [&win_dd]() -> std::string {
+    const auto flat_topology { flattenTopology(win_dd.getCurrentTopology()) };
+    for (const auto &device_id : flat_topology) {
+      if (win_dd.isPrimary(device_id)) {
+        return device_id;
+      }
+    }
+
+    return {};
+  }()]() {
+    static_cast<void>(win_dd.setAsPrimary(primary_device));
+  });
+}

--- a/tests/unit/windows/utils/helpers.h
+++ b/tests/unit/windows/utils/helpers.h
@@ -12,4 +12,4 @@ std::set<std::string>
 flattenTopology(const display_device::ActiveTopology &topology);
 
 std::optional<std::vector<std::string>>
-getAvailableDevices(display_device::WinApiLayer &layer, bool only_valid_output = false);
+getAvailableDevices(display_device::WinApiLayer &layer, bool only_valid_output = true);


### PR DESCRIPTION
## Description

Added methods for handling primary displays.

Also disabled the usage of the default CI display by default as you just cannot modify it's mode structure at all (also the current one is invalid by default)... Sadly this means that most of `MixedTopology` UTs will not run on CI as only 2 additional VDDs can be added :/

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
