### PR TITLE
feat: Add logic for resetting persistence

### DIFF
--- a/src/common/include/displaydevice/settingsmanagerinterface.h
+++ b/src/common/include/displaydevice/settingsmanagerinterface.h
@@ -88,27 +88,29 @@ namespace display_device {
 
     /**
      * @brief Reset the persistence in case the settings cannot be reverted.
+     * @returns True if persistence was reset, false otherwise.
      *
      * In case the settings cannot be reverted, because the display is turned or some other reason,
-     * this allows to "accept" the current state and start from scratch.
+     * this allows to "accept" the current state and start from scratch, but only if the persistence was
+     * cleared successfuly.
      *
      * EXAMPLES:
      * ```cpp
      * SettingsManagerInterface* iface = getIface(...);
-     * const auto result = iface->applySettings(config);
+     * auto result = iface->applySettings(config);
      * if (result == ApplyResult::Ok) {
      *   // Wait for some time
      *   if (!iface->revertSettings()) {
      *     // Wait for user input
      *     const bool user_wants_reset { true };
      *     if (user_wants_reset) {
-     *       iface->resetPersistence();
+     *       result = iface->resetPersistence();
      *     }
      *   }
      * }
      * ```
      */
-    // virtual void
-    // resetPersistence() = 0;
+    [[nodiscard]] virtual bool
+    resetPersistence() = 0;
   };
 }  // namespace display_device

--- a/src/windows/include/displaydevice/windows/settingsmanager.h
+++ b/src/windows/include/displaydevice/windows/settingsmanager.h
@@ -42,6 +42,10 @@ namespace display_device {
     [[nodiscard]] bool
     revertSettings() override;
 
+    /** For details @see SettingsManagerInterface::resetPersistence */
+    [[nodiscard]] bool
+    resetPersistence() override;
+
   protected:
     /**
      * @brief Preps the topology so that the further settings could be applied.

--- a/src/windows/settingsmanagergeneral.cpp
+++ b/src/windows/settingsmanagergeneral.cpp
@@ -35,4 +35,23 @@ namespace display_device {
   SettingsManager::getDisplayName(const std::string &device_id) const {
     return m_dd_api->getDisplayName(device_id);
   }
+
+  bool
+  SettingsManager::resetPersistence() {
+    // Trying to revert one more time in case we succeed.
+    if (revertSettings()) {
+      return true;
+    }
+
+    DD_LOG(info) << "Trying to reset persistent display device settings.";
+    if (!m_persistence_state->persistState(std::nullopt)) {
+      DD_LOG(error) << "Failed to clear persistence!";
+      return false;
+    }
+
+    if (m_audio_context_api->isCaptured()) {
+      m_audio_context_api->release();
+    }
+    return true;
+  }
 }  // namespace display_device

--- a/tests/unit/windows/test_settingsmanagergeneral.cpp
+++ b/tests/unit/windows/test_settingsmanagergeneral.cpp
@@ -90,3 +90,62 @@ TEST_F_S_MOCKED(GetDisplayName) {
 
   EXPECT_EQ(getImpl().getDisplayName("DeviceId1"), "DeviceName1");
 }
+
+TEST_F_S_MOCKED(ResetPersistence, NoPersistence) {
+  EXPECT_CALL(*m_settings_persistence_api, load())
+    .Times(1)
+    .WillOnce(Return(serializeState(ut_consts::SDCS_EMPTY)));
+
+  EXPECT_TRUE(getImpl().resetPersistence());
+}
+
+TEST_F_S_MOCKED(ResetPersistence, FailedToReset) {
+  EXPECT_CALL(*m_settings_persistence_api, load())
+    .Times(1)
+    .WillOnce(Return(serializeState(ut_consts::SDCS_FULL)));
+  EXPECT_CALL(*m_dd_api, isApiAccessAvailable())
+    .Times(1)
+    .WillOnce(Return(false));
+  EXPECT_CALL(*m_settings_persistence_api, clear())
+    .Times(1)
+    .WillOnce(Return(false));
+
+  EXPECT_FALSE(getImpl().resetPersistence());
+}
+
+TEST_F_S_MOCKED(ResetPersistence, PersistenceReset, NoCapturedDevice) {
+  EXPECT_CALL(*m_settings_persistence_api, load())
+    .Times(1)
+    .WillOnce(Return(serializeState(ut_consts::SDCS_FULL)));
+  EXPECT_CALL(*m_dd_api, isApiAccessAvailable())
+    .Times(1)
+    .WillOnce(Return(false));
+  EXPECT_CALL(*m_settings_persistence_api, clear())
+    .Times(1)
+    .WillOnce(Return(true));
+  EXPECT_CALL(*m_audio_context_api, isCaptured())
+    .Times(1)
+    .WillOnce(Return(false))
+    .RetiresOnSaturation();
+
+  EXPECT_TRUE(getImpl().resetPersistence());
+}
+
+TEST_F_S_MOCKED(ResetPersistence, PersistenceReset, WithCapturedDevice) {
+  EXPECT_CALL(*m_settings_persistence_api, load())
+    .Times(1)
+    .WillOnce(Return(serializeState(ut_consts::SDCS_FULL)));
+  EXPECT_CALL(*m_dd_api, isApiAccessAvailable())
+    .Times(1)
+    .WillOnce(Return(false));
+  EXPECT_CALL(*m_settings_persistence_api, clear())
+    .Times(1)
+    .WillOnce(Return(true));
+  EXPECT_CALL(*m_audio_context_api, isCaptured())
+    .Times(1)
+    .WillOnce(Return(true));
+  EXPECT_CALL(*m_audio_context_api, release())
+    .Times(1);
+
+  EXPECT_TRUE(getImpl().resetPersistence());
+}


### PR DESCRIPTION
## Description
Add logic for resetting persistence

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
