### PR TITLE
fix: Fix unstable RetryScheduler test case

### DIFF
--- a/tests/unit/general/test_retry_scheduler.cpp
+++ b/tests/unit/general/test_retry_scheduler.cpp
@@ -132,11 +132,10 @@ TEST_F_S(Schedule, ImmediateExecution) {
   },
     1ms);
 
-  while (!first_call_scheduler_thread_id || !second_call_scheduler_thread_id) {
+  while (m_impl.isScheduled()) {
     std::this_thread::sleep_for(1ms);
   }
 
-  EXPECT_FALSE(m_impl.isScheduled());
   EXPECT_TRUE(first_call_scheduler_thread_id);
   EXPECT_TRUE(second_call_scheduler_thread_id);
 


### PR DESCRIPTION
## Description
Fix unstable RetryScheduler test case

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
