### PR TITLE
feat: Simplify persistence load error handling

### DIFF
--- a/src/windows/include/display_device/windows/persistent_state.h
+++ b/src/windows/include/display_device/windows/persistent_state.h
@@ -16,10 +16,9 @@ namespace display_device {
     /**
      * Default constructor for the class.
      * @param settings_persistence_api [Optional] A pointer to the Settings Persistence interface.
-     * @param fallback_state Fallback state to be used if the persistence interface fails to load data (or it is invalid).
-     *                       If no fallback is provided in such case, the constructor will throw.
+     * @param throw_on_load_error Specify whether to throw exception in constructor in case settings fail to load.
      */
-    explicit PersistentState(std::shared_ptr<SettingsPersistenceInterface> settings_persistence_api, const std::optional<SingleDisplayConfigState> &fallback_state = SingleDisplayConfigState {});
+    explicit PersistentState(std::shared_ptr<SettingsPersistenceInterface> settings_persistence_api, bool throw_on_load_error = false);
 
     /**
      * @brief Store the new state via the interface and cache it.

--- a/src/windows/persistent_state.cpp
+++ b/src/windows/persistent_state.cpp
@@ -7,7 +7,7 @@
 #include "display_device/windows/json.h"
 
 namespace display_device {
-  PersistentState::PersistentState(std::shared_ptr<SettingsPersistenceInterface> settings_persistence_api, const std::optional<SingleDisplayConfigState> &fallback_state):
+  PersistentState::PersistentState(std::shared_ptr<SettingsPersistenceInterface> settings_persistence_api, const bool throw_on_load_error):
       m_settings_persistence_api { std::move(settings_persistence_api) } {
     if (!m_settings_persistence_api) {
       m_settings_persistence_api = std::make_shared<NoopSettingsPersistence>();
@@ -27,11 +27,12 @@ namespace display_device {
     }
 
     if (!error_message.empty()) {
-      if (!fallback_state) {
+      if (throw_on_load_error) {
         throw std::runtime_error { error_message };
       }
 
-      m_cached_state = *fallback_state;
+      DD_LOG(error) << error_message;
+      m_cached_state = std::nullopt;
     }
   }
 


### PR DESCRIPTION
## Description
Simplify persistence load error handling. Incorrect `fallback` state could break the assumptions and we don't want that...

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
