### PR TITLE
feat: externalize workarounds for Windows

### DIFF
--- a/src/common/include/display_device/detail/json_serializer_details.h
+++ b/src/common/include/display_device/detail/json_serializer_details.h
@@ -109,7 +109,7 @@ namespace nlohmann {
         nlohmann_json_t = std::nullopt;
       }
       else {
-        nlohmann_json_t = nlohmann_json_j.template get<T>();
+        nlohmann_json_t = nlohmann_json_j.get<T>();
       }
     }
   };
@@ -136,6 +136,24 @@ namespace nlohmann {
         const std::string error { "Could not parse variant from type " + nlohmann_json_j.at("type").get<std::string>() + "!" };
         throw std::runtime_error(error);
       }
+    }
+  };
+
+  // Specialization for chrono duration.
+  template <class Rep, class Period>
+  struct adl_serializer<std::chrono::duration<Rep, Period>> {
+    using NanoRep = decltype(std::chrono::nanoseconds {}.count());
+    static_assert(std::numeric_limits<Rep>::max() <= std::numeric_limits<NanoRep>::max(),
+      "Duration support above nanoseconds have not been tested/verified yet!");
+
+    static void
+    to_json(json &nlohmann_json_j, const std::chrono::duration<Rep, Period> &nlohmann_json_t) {
+      nlohmann_json_j = nlohmann_json_t.count();
+    }
+
+    static void
+    from_json(const json &nlohmann_json_j, std::chrono::duration<Rep, Period> &nlohmann_json_t) {
+      nlohmann_json_t = std::chrono::duration<Rep, Period> { nlohmann_json_j.get<Rep>() };
     }
   };
 }  // namespace nlohmann

--- a/src/common/include/display_device/json.h
+++ b/src/common/include/display_device/json.h
@@ -25,6 +25,7 @@
 namespace display_device {
   extern const std::optional<unsigned int> JSON_COMPACT;
 
+  DD_JSON_DECLARE_CONVERTER(EnumeratedDevice)
   DD_JSON_DECLARE_CONVERTER(EnumeratedDeviceList)
   DD_JSON_DECLARE_CONVERTER(SingleDisplayConfiguration)
   DD_JSON_DECLARE_CONVERTER(std::set<std::string>)

--- a/src/common/json.cpp
+++ b/src/common/json.cpp
@@ -13,6 +13,7 @@
 // clang-format on
 
 namespace display_device {
+  DD_JSON_DEFINE_CONVERTER(EnumeratedDevice)
   DD_JSON_DEFINE_CONVERTER(EnumeratedDeviceList)
   DD_JSON_DEFINE_CONVERTER(SingleDisplayConfiguration)
   DD_JSON_DEFINE_CONVERTER(std::set<std::string>)

--- a/src/windows/include/display_device/windows/detail/json_serializer.h
+++ b/src/windows/include/display_device/windows/detail/json_serializer.h
@@ -14,5 +14,6 @@ namespace display_device {
   DD_JSON_DECLARE_SERIALIZE_TYPE(SingleDisplayConfigState::Initial)
   DD_JSON_DECLARE_SERIALIZE_TYPE(SingleDisplayConfigState::Modified)
   DD_JSON_DECLARE_SERIALIZE_TYPE(SingleDisplayConfigState)
+  DD_JSON_DECLARE_SERIALIZE_TYPE(WinWorkarounds)
 }  // namespace display_device
 #endif

--- a/src/windows/include/display_device/windows/json.h
+++ b/src/windows/include/display_device/windows/json.h
@@ -14,4 +14,5 @@ namespace display_device {
   DD_JSON_DECLARE_CONVERTER(DeviceDisplayModeMap)
   DD_JSON_DECLARE_CONVERTER(HdrStateMap)
   DD_JSON_DECLARE_CONVERTER(SingleDisplayConfigState)
+  DD_JSON_DECLARE_CONVERTER(WinWorkarounds)
 }  // namespace display_device

--- a/src/windows/include/display_device/windows/settings_manager.h
+++ b/src/windows/include/display_device/windows/settings_manager.h
@@ -5,7 +5,6 @@
 #pragma once
 
 // system includes
-#include <chrono>
 #include <memory>
 
 // local includes
@@ -25,11 +24,13 @@ namespace display_device {
      * @param dd_api A pointer to the Windows Display Device interface. Will throw on nullptr!
      * @param audio_context_api [Optional] A pointer to the Audio Context interface.
      * @param persistent_state A pointer to a class for managing persistence.
+     * @param workarounds Workaround settings for the APIs.
      */
     explicit SettingsManager(
       std::shared_ptr<WinDisplayDeviceInterface> dd_api,
       std::shared_ptr<AudioContextInterface> audio_context_api,
-      std::unique_ptr<PersistentState> persistent_state);
+      std::unique_ptr<PersistentState> persistent_state,
+      WinWorkarounds workarounds);
 
     /** For details @see SettingsManagerInterface::enumAvailableDevices */
     [[nodiscard]] EnumeratedDeviceList
@@ -115,9 +116,6 @@ namespace display_device {
     std::shared_ptr<WinDisplayDeviceInterface> m_dd_api;
     std::shared_ptr<AudioContextInterface> m_audio_context_api;
     std::unique_ptr<PersistentState> m_persistence_state;
-
-  private:
-    /** @see win_utils::blankHdrStates for more details. */
-    std::chrono::milliseconds m_hdr_blank_delay { 500 };  // 500ms should be more than enough...
+    WinWorkarounds m_workarounds;
   };
 }  // namespace display_device

--- a/src/windows/include/display_device/windows/settings_utils.h
+++ b/src/windows/include/display_device/windows/settings_utils.h
@@ -165,9 +165,10 @@ namespace display_device::win_utils {
    *
    * @param win_dd Interface for interacting with the OS.
    * @param delay Delay between OFF and ON states (ON -> OFF -> DELAY -> ON).
+   *              If null optional is provided, the function does nothing.
    */
   void
-  blankHdrStates(WinDisplayDeviceInterface &win_dd, std::chrono::milliseconds delay);
+  blankHdrStates(WinDisplayDeviceInterface &win_dd, const std::optional<std::chrono::milliseconds>& delay);
 
   /**
    * @brief Make guard function for the topology.

--- a/src/windows/include/display_device/windows/settings_utils.h
+++ b/src/windows/include/display_device/windows/settings_utils.h
@@ -168,7 +168,7 @@ namespace display_device::win_utils {
    *              If null optional is provided, the function does nothing.
    */
   void
-  blankHdrStates(WinDisplayDeviceInterface &win_dd, const std::optional<std::chrono::milliseconds>& delay);
+  blankHdrStates(WinDisplayDeviceInterface &win_dd, const std::optional<std::chrono::milliseconds> &delay);
 
   /**
    * @brief Make guard function for the topology.

--- a/src/windows/include/display_device/windows/types.h
+++ b/src/windows/include/display_device/windows/types.h
@@ -177,7 +177,7 @@ namespace display_device {
    * @brief Settings for workarounds/hacks for Windows.
    */
   struct WinWorkarounds {
-    std::optional<std::chrono::milliseconds> m_hdr_blank_delay { std::nullopt }; ///< @seealso{win_utils::blankHdrStates for more details.}
+    std::optional<std::chrono::milliseconds> m_hdr_blank_delay { std::nullopt };  ///< @seealso{win_utils::blankHdrStates for more details.}
 
     /**
      * @brief Comparator for strict equality.

--- a/src/windows/include/display_device/windows/types.h
+++ b/src/windows/include/display_device/windows/types.h
@@ -177,7 +177,7 @@ namespace display_device {
    * @brief Settings for workarounds/hacks for Windows.
    */
   struct WinWorkarounds {
-    std::optional<std::chrono::milliseconds> m_hdr_blank_delay { std::nullopt }; /**< @seealso{win_utils::blankHdrStates for more details.} */
+    std::optional<std::chrono::milliseconds> m_hdr_blank_delay { std::nullopt }; ///< @seealso{win_utils::blankHdrStates for more details.}
 
     /**
      * @brief Comparator for strict equality.

--- a/src/windows/include/display_device/windows/types.h
+++ b/src/windows/include/display_device/windows/types.h
@@ -177,8 +177,7 @@ namespace display_device {
    * @brief Settings for workarounds/hacks for Windows.
    */
   struct WinWorkarounds {
-    /** @see win_utils::blankHdrStates for more details. */
-    std::optional<std::chrono::milliseconds> m_hdr_blank_delay { std::nullopt };
+    std::optional<std::chrono::milliseconds> m_hdr_blank_delay { std::nullopt }; /**< @seealso{win_utils::blankHdrStates for more details.} */
 
     /**
      * @brief Comparator for strict equality.

--- a/src/windows/include/display_device/windows/types.h
+++ b/src/windows/include/display_device/windows/types.h
@@ -11,6 +11,7 @@
 #include <windows.h>
 
 // system includes
+#include <chrono>
 #include <functional>
 #include <map>
 #include <set>
@@ -171,4 +172,18 @@ namespace display_device {
    * @brief Default function type used for cleanup/guard functions.
    */
   using DdGuardFn = std::function<void()>;
+
+  /**
+   * @brief Settings for workarounds/hacks for Windows.
+   */
+  struct WinWorkarounds {
+    /** @see win_utils::blankHdrStates for more details. */
+    std::optional<std::chrono::milliseconds> m_hdr_blank_delay { std::nullopt };
+
+    /**
+     * @brief Comparator for strict equality.
+     */
+    friend bool
+    operator==(const WinWorkarounds &lhs, const WinWorkarounds &rhs);
+  };
 }  // namespace display_device

--- a/src/windows/json.cpp
+++ b/src/windows/json.cpp
@@ -19,4 +19,5 @@ namespace display_device {
   DD_JSON_DEFINE_CONVERTER(DeviceDisplayModeMap)
   DD_JSON_DEFINE_CONVERTER(HdrStateMap)
   DD_JSON_DEFINE_CONVERTER(SingleDisplayConfigState)
+  DD_JSON_DEFINE_CONVERTER(WinWorkarounds)
 }  // namespace display_device

--- a/src/windows/json_serializer.cpp
+++ b/src/windows/json_serializer.cpp
@@ -15,4 +15,5 @@ namespace display_device {
   DD_JSON_DEFINE_SERIALIZE_STRUCT(SingleDisplayConfigState::Initial, topology, primary_devices)
   DD_JSON_DEFINE_SERIALIZE_STRUCT(SingleDisplayConfigState::Modified, topology, original_modes, original_hdr_states, original_primary_device)
   DD_JSON_DEFINE_SERIALIZE_STRUCT(SingleDisplayConfigState, initial, modified)
+  DD_JSON_DEFINE_SERIALIZE_STRUCT(WinWorkarounds, hdr_blank_delay)
 }  // namespace display_device

--- a/src/windows/settings_manager_apply.cpp
+++ b/src/windows/settings_manager_apply.cpp
@@ -47,7 +47,7 @@ namespace display_device {
     bool system_settings_touched { false };
     boost::scope::scope_exit hdr_blank_always_executed_guard { [this, &system_settings_touched]() {
       if (system_settings_touched) {
-        win_utils::blankHdrStates(*m_dd_api, m_hdr_blank_delay);
+        win_utils::blankHdrStates(*m_dd_api, m_workarounds.m_hdr_blank_delay);
       }
     } };
 

--- a/src/windows/settings_manager_general.cpp
+++ b/src/windows/settings_manager_general.cpp
@@ -8,15 +8,18 @@
 // local includes
 #include "display_device/logging.h"
 #include "display_device/noop_audio_context.h"
+#include "display_device/windows/json.h"
 
 namespace display_device {
   SettingsManager::SettingsManager(
     std::shared_ptr<WinDisplayDeviceInterface> dd_api,
     std::shared_ptr<AudioContextInterface> audio_context_api,
-    std::unique_ptr<PersistentState> persistent_state):
+    std::unique_ptr<PersistentState> persistent_state,
+    WinWorkarounds workarounds):
       m_dd_api { std::move(dd_api) },
       m_audio_context_api { std::move(audio_context_api) },
-      m_persistence_state { std::move(persistent_state) } {
+      m_persistence_state { std::move(persistent_state) },
+      m_workarounds { std::move(workarounds) } {
     if (!m_dd_api) {
       throw std::logic_error { "Nullptr provided for WinDisplayDeviceInterface in SettingsManager!" };
     }
@@ -28,6 +31,9 @@ namespace display_device {
     if (!m_persistence_state) {
       throw std::logic_error { "Nullptr provided for PersistentState in SettingsManager!" };
     }
+
+    DD_LOG(info) << "Provided workaround settings for SettingsManager:\n"
+                 << toJson(m_workarounds);
   }
 
   EnumeratedDeviceList

--- a/src/windows/settings_manager_revert.cpp
+++ b/src/windows/settings_manager_revert.cpp
@@ -47,7 +47,7 @@ namespace display_device {
     bool system_settings_touched { false };
     boost::scope::scope_exit hdr_blank_always_executed_guard { [this, &system_settings_touched]() {
       if (system_settings_touched) {
-        win_utils::blankHdrStates(*m_dd_api, m_hdr_blank_delay);
+        win_utils::blankHdrStates(*m_dd_api, m_workarounds.m_hdr_blank_delay);
       }
     } };
     boost::scope::scope_exit topology_prep_guard { [this, &cached_state, &current_topology, &system_settings_touched]() {

--- a/src/windows/settings_utils.cpp
+++ b/src/windows/settings_utils.cpp
@@ -358,7 +358,11 @@ namespace display_device::win_utils {
   }
 
   void
-  blankHdrStates(WinDisplayDeviceInterface &win_dd, const std::chrono::milliseconds delay) {
+  blankHdrStates(WinDisplayDeviceInterface &win_dd, const std::optional<std::chrono::milliseconds>& delay) {
+    if (!delay) {
+      return;
+    }
+
     const auto topology { win_dd.getCurrentTopology() };
     if (!win_dd.isTopologyValid(topology)) {
       DD_LOG(error) << "Got an invalid topology while trying to blank HDR states!";
@@ -390,13 +394,13 @@ namespace display_device::win_utils {
       return;
     }
 
-    DD_LOG(info) << "Applying HDR state \"blank\" workaround (" << delay.count() << "ms) to devices: " << toJson(device_ids, JSON_COMPACT);
+    DD_LOG(info) << "Applying HDR state \"blank\" workaround (" << delay->count() << "ms) to devices: " << toJson(device_ids, JSON_COMPACT);
     if (!win_dd.setHdrStates(inverse_states)) {
       DD_LOG(error) << "Failed to apply inverse HDR states during \"blank\"!";
       return;
     }
 
-    std::this_thread::sleep_for(delay);
+    std::this_thread::sleep_for(*delay);
     if (!win_dd.setHdrStates(original_states)) {
       DD_LOG(error) << "Failed to apply original HDR states during \"blank\"!";
     }

--- a/src/windows/settings_utils.cpp
+++ b/src/windows/settings_utils.cpp
@@ -358,7 +358,7 @@ namespace display_device::win_utils {
   }
 
   void
-  blankHdrStates(WinDisplayDeviceInterface &win_dd, const std::optional<std::chrono::milliseconds>& delay) {
+  blankHdrStates(WinDisplayDeviceInterface &win_dd, const std::optional<std::chrono::milliseconds> &delay) {
     if (!delay) {
       return;
     }

--- a/src/windows/types.cpp
+++ b/src/windows/types.cpp
@@ -30,4 +30,9 @@ namespace display_device {
   operator==(const SingleDisplayConfigState &lhs, const SingleDisplayConfigState &rhs) {
     return lhs.m_initial == rhs.m_initial && lhs.m_modified == rhs.m_modified;
   }
+
+  bool
+  operator==(const WinWorkarounds &lhs, const WinWorkarounds &rhs) {
+    return lhs.m_hdr_blank_delay == rhs.m_hdr_blank_delay;
+  }
 }  // namespace display_device

--- a/tests/unit/general/test_json_converter.cpp
+++ b/tests/unit/general/test_json_converter.cpp
@@ -6,6 +6,37 @@ namespace {
 #define TEST_F_S(...) DD_MAKE_TEST(TEST_F, JsonConverterTest, __VA_ARGS__)
 }  // namespace
 
+TEST_F_S(EnumeratedDevice) {
+  display_device::EnumeratedDevice item_1 {
+    "ID_1",
+    "NAME_2",
+    "FU_NAME_3",
+    display_device::EnumeratedDevice::Info {
+        { 1920, 1080 },
+        display_device::Rational { 175, 100 },
+        119.9554,
+        false,
+        { 1, 2 },
+        display_device::HdrState::Enabled }
+  };
+  display_device::EnumeratedDevice item_2 {
+    "ID_2",
+    "NAME_2",
+    "FU_NAME_2",
+    display_device::EnumeratedDevice::Info {
+        { 1920, 1080 },
+        1.75,
+        display_device::Rational { 1199554, 10000 },
+        true,
+        { 0, 0 },
+        display_device::HdrState::Disabled }
+  };
+
+  executeTestCase(display_device::EnumeratedDevice {}, R"({"device_id":"","display_name":"","friendly_name":"","info":null})");
+  executeTestCase(item_1, R"({"device_id":"ID_1","display_name":"NAME_2","friendly_name":"FU_NAME_3","info":{"hdr_state":"Enabled","origin_point":{"x":1,"y":2},"primary":false,"refresh_rate":{"type":"double","value":119.9554},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"rational","value":{"denominator":100,"numerator":175}}}})");
+  executeTestCase(item_2, R"({"device_id":"ID_2","display_name":"NAME_2","friendly_name":"FU_NAME_2","info":{"hdr_state":"Disabled","origin_point":{"x":0,"y":0},"primary":true,"refresh_rate":{"type":"rational","value":{"denominator":10000,"numerator":1199554}},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"double","value":1.75}}})");
+}
+
 TEST_F_S(EnumeratedDeviceList) {
   display_device::EnumeratedDevice item_1 {
     "ID_1",

--- a/tests/unit/general/test_json_converter.cpp
+++ b/tests/unit/general/test_json_converter.cpp
@@ -12,24 +12,24 @@ TEST_F_S(EnumeratedDevice) {
     "NAME_2",
     "FU_NAME_3",
     display_device::EnumeratedDevice::Info {
-        { 1920, 1080 },
-        display_device::Rational { 175, 100 },
-        119.9554,
-        false,
-        { 1, 2 },
-        display_device::HdrState::Enabled }
+      { 1920, 1080 },
+      display_device::Rational { 175, 100 },
+      119.9554,
+      false,
+      { 1, 2 },
+      display_device::HdrState::Enabled }
   };
   display_device::EnumeratedDevice item_2 {
     "ID_2",
     "NAME_2",
     "FU_NAME_2",
     display_device::EnumeratedDevice::Info {
-        { 1920, 1080 },
-        1.75,
-        display_device::Rational { 1199554, 10000 },
-        true,
-        { 0, 0 },
-        display_device::HdrState::Disabled }
+      { 1920, 1080 },
+      1.75,
+      display_device::Rational { 1199554, 10000 },
+      true,
+      { 0, 0 },
+      display_device::HdrState::Disabled }
   };
 
   executeTestCase(display_device::EnumeratedDevice {}, R"({"device_id":"","display_name":"","friendly_name":"","info":null})");

--- a/tests/unit/windows/test_json_converter.cpp
+++ b/tests/unit/windows/test_json_converter.cpp
@@ -40,3 +40,12 @@ TEST_F_S(SingleDisplayConfigState) {
   executeTestCase(display_device::SingleDisplayConfigState {}, R"({"initial":{"primary_devices":[],"topology":[]},"modified":{"original_hdr_states":{},"original_modes":{},"original_primary_device":"","topology":[]}})");
   executeTestCase(valid_input, R"({"initial":{"primary_devices":["DeviceId1"],"topology":[["DeviceId1"]]},"modified":{"original_hdr_states":{"DeviceId2":"Disabled"},"original_modes":{"DeviceId2":{"refresh_rate":{"denominator":1,"numerator":120},"resolution":{"height":1080,"width":1920}}},"original_primary_device":"DeviceId2","topology":[["DeviceId2"]]}})");
 }
+
+TEST_F_S(WinWorkarounds) {
+  display_device::WinWorkarounds input {
+    std::chrono::milliseconds { 500 }
+  };
+
+  executeTestCase(display_device::WinWorkarounds {}, R"({"hdr_blank_delay":null})");
+  executeTestCase(input, R"({"hdr_blank_delay":500})");
+}

--- a/tests/unit/windows/test_settings_manager_apply.cpp
+++ b/tests/unit/windows/test_settings_manager_apply.cpp
@@ -47,7 +47,10 @@ namespace {
     display_device::SettingsManager &
     getImpl() {
       if (!m_impl) {
-        m_impl = std::make_unique<display_device::SettingsManager>(m_dd_api, m_audio_context_api, std::make_unique<display_device::PersistentState>(m_settings_persistence_api));
+        m_impl = std::make_unique<display_device::SettingsManager>(m_dd_api, m_audio_context_api, std::make_unique<display_device::PersistentState>(m_settings_persistence_api),
+          display_device::WinWorkarounds {
+            .m_hdr_blank_delay = std::chrono::milliseconds { 123 }  // Value is irrelevant for the tests
+          });
       }
 
       return *m_impl;

--- a/tests/unit/windows/test_settings_manager_general.cpp
+++ b/tests/unit/windows/test_settings_manager_general.cpp
@@ -23,7 +23,7 @@ namespace {
     display_device::SettingsManager &
     getImpl() {
       if (!m_impl) {
-        m_impl = std::make_unique<display_device::SettingsManager>(m_dd_api, m_audio_context_api, std::make_unique<display_device::PersistentState>(m_settings_persistence_api));
+        m_impl = std::make_unique<display_device::SettingsManager>(m_dd_api, m_audio_context_api, std::make_unique<display_device::PersistentState>(m_settings_persistence_api), display_device::WinWorkarounds {});
       }
 
       return *m_impl;
@@ -42,7 +42,7 @@ namespace {
 }  // namespace
 
 TEST_F_S_MOCKED(NullptrDisplayDeviceApiProvided) {
-  EXPECT_THAT([]() { const display_device::SettingsManager settings_manager(nullptr, nullptr, nullptr); },
+  EXPECT_THAT([]() { const display_device::SettingsManager settings_manager(nullptr, nullptr, nullptr, {}); },
     ThrowsMessage<std::logic_error>(HasSubstr("Nullptr provided for WinDisplayDeviceInterface in SettingsManager!")));
 }
 
@@ -53,12 +53,12 @@ TEST_F_S_MOCKED(NoopAudioContext) {
     using SettingsManager::SettingsManager;
   };
 
-  const NakedSettingsManager settings_manager { m_dd_api, nullptr, std::make_unique<display_device::PersistentState>(nullptr) };
+  const NakedSettingsManager settings_manager { m_dd_api, nullptr, std::make_unique<display_device::PersistentState>(nullptr), {} };
   EXPECT_TRUE(std::dynamic_pointer_cast<display_device::NoopAudioContext>(settings_manager.m_audio_context_api) != nullptr);
 }
 
 TEST_F_S_MOCKED(NullptrPersistentStateProvided) {
-  EXPECT_THAT([this]() { const display_device::SettingsManager settings_manager(m_dd_api, nullptr, nullptr); },
+  EXPECT_THAT([this]() { const display_device::SettingsManager settings_manager(m_dd_api, nullptr, nullptr, {}); },
     ThrowsMessage<std::logic_error>(HasSubstr("Nullptr provided for PersistentState in SettingsManager!")));
 }
 

--- a/tests/unit/windows/test_settings_manager_revert.cpp
+++ b/tests/unit/windows/test_settings_manager_revert.cpp
@@ -39,7 +39,10 @@ namespace {
     display_device::SettingsManager &
     getImpl() {
       if (!m_impl) {
-        m_impl = std::make_unique<display_device::SettingsManager>(m_dd_api, m_audio_context_api, std::make_unique<display_device::PersistentState>(m_settings_persistence_api));
+        m_impl = std::make_unique<display_device::SettingsManager>(m_dd_api, m_audio_context_api, std::make_unique<display_device::PersistentState>(m_settings_persistence_api),
+          display_device::WinWorkarounds {
+            .m_hdr_blank_delay = std::chrono::milliseconds { 123 }  // Value is irrelevant for the tests
+          });
       }
 
       return *m_impl;

--- a/tests/unit/windows/test_settings_utils.cpp
+++ b/tests/unit/windows/test_settings_utils.cpp
@@ -363,6 +363,10 @@ TEST_F_S_MOCKED(BlankHdrStates, FailedToApplyOriginalStates) {
   EXPECT_NO_THROW(display_device::win_utils::blankHdrStates(m_dd_api, std::chrono::milliseconds(0)));
 }
 
+TEST_F_S_MOCKED(BlankHdrStates, NullDelay) {
+  EXPECT_NO_THROW(display_device::win_utils::blankHdrStates(m_dd_api, std::nullopt));
+}
+
 TEST_F_S_MOCKED(BlankHdrStates, Success) {
   const display_device::HdrStateMap initial_states {
     { "DeviceId1", { display_device::HdrState::Enabled } },

--- a/tests/unit/windows/test_win_playground.cpp
+++ b/tests/unit/windows/test_win_playground.cpp
@@ -29,7 +29,7 @@ namespace {
     std::unique_ptr<display_device::SettingsManager> m_settings { std::make_unique<display_device::SettingsManager>(
       std::make_shared<display_device::WinDisplayDevice>(std::make_shared<display_device::WinApiLayer>()),
       nullptr,
-      std::make_unique<display_device::PersistentState>(nullptr)) };
+      std::make_unique<display_device::PersistentState>(nullptr), display_device::WinWorkarounds {}) };
   };
 
   // Specialized TEST macro(s) for this test file


### PR DESCRIPTION
## Description
Externalize workarounds for Windows.

Currently the HDR workaround for VDD is always applied (for toggling on/off HDR display states), even when VDD is not used and the workaround is probably not needed.
We should allow users to toggle such workarounds as they wish.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
