### PR TITLE
fix: do not build docs for external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,22 +27,24 @@ option(BUILD_TESTS "Build tests" ON)
 #
 # Testing and documentation are only available if this is the main project
 #
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTS)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     if(BUILD_DOCS)
         add_subdirectory(third-party/doxyconfig docs)
     endif()
 
-    #
-    # Additional setup for coverage
-    # https://gcovr.com/en/stable/guide/compiling.html#compiler-options
-    #
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage -O0")
-        set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage -O0")
-    endif()
+    if(BUILD_TESTS)
+        #
+        # Additional setup for coverage
+        # https://gcovr.com/en/stable/guide/compiling.html#compiler-options
+        #
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage -O0")
+            set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage -O0")
+        endif()
 
-    enable_testing()
-    add_subdirectory(tests)
+        enable_testing()
+        add_subdirectory(tests)
+    endif()
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,16 +25,13 @@ option(BUILD_DOCS "Build documentation" ON)
 option(BUILD_TESTS "Build tests" ON)
 
 #
-# Documentation
-#
-if(BUILD_DOCS)
-    add_subdirectory(third-party/doxyconfig docs)
-endif()
-
-#
-# Testing only available if this is the main project
+# Testing and documentation are only available if this is the main project
 #
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTS)
+    if(BUILD_DOCS)
+        add_subdirectory(third-party/doxyconfig docs)
+    endif()
+
     #
     # Additional setup for coverage
     # https://gcovr.com/en/stable/guide/compiling.html#compiler-options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,10 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 #
 # Project optional configuration
 #
-option(BUILD_DOCS "Build documentation" ON)
-option(BUILD_TESTS "Build tests" ON)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    option(BUILD_DOCS "Build documentation" ON)
+    option(BUILD_TESTS "Build tests" ON)
+endif()
 
 #
 # Testing and documentation are only available if this is the main project


### PR DESCRIPTION
## Description
Do not build docs for external projects. Sunshine and libdd are fighting over target names otherwise.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
