### PR TITLE
feat: add const version of RetryScheduler::execute

### DIFF
--- a/src/common/include/display_device/retry_scheduler.h
+++ b/src/common/include/display_device/retry_scheduler.h
@@ -311,7 +311,7 @@ namespace display_device {
       requires detail::ExecuteCallbackLikeConst<T, FunctionT>
     auto
     execute(FunctionT exec_fn) const {
-      return const_cast<RetryScheduler *>(this)->execute(exec_fn);
+      return const_cast<RetryScheduler *>(this)->execute(std::move(exec_fn));
     }
 
     /**

--- a/src/common/include/display_device/retry_scheduler.h
+++ b/src/common/include/display_device/retry_scheduler.h
@@ -73,6 +73,15 @@ namespace display_device {
     };
 
     /**
+     * @brief Check if the function signature matches the acceptable signature for RetryScheduler::execute (const)
+     *        without a stop token.
+     */
+    template <class T, class FunctionT>
+    concept ExecuteWithoutStopTokenConst = requires(FunctionT exec_fn) {
+      exec_fn(std::declval<const T &>());
+    };
+
+    /**
      * @brief Check if the function signature matches the acceptable signature for RetryScheduler::execute
      *        with a stop token.
      */
@@ -82,10 +91,25 @@ namespace display_device {
     };
 
     /**
+     * @brief Check if the function signature matches the acceptable signature for RetryScheduler::execute (const)
+     *        with a stop token.
+     */
+    template <class T, class FunctionT>
+    concept ExecuteWithStopTokenConst = requires(FunctionT exec_fn) {
+      exec_fn(std::declval<const T &>(), std::declval<const SchedulerStopToken &>());
+    };
+
+    /**
      * @brief Check if the function signature matches the acceptable signature for RetryScheduler::execute.
      */
     template <class T, class FunctionT>
     concept ExecuteCallbackLike = ExecuteWithoutStopToken<T, FunctionT> || ExecuteWithStopToken<T, FunctionT>;
+
+    /**
+     * @brief Check if the function signature matches the acceptable signature for RetryScheduler::execute (const).
+     */
+    template <class T, class FunctionT>
+    concept ExecuteCallbackLikeConst = ExecuteWithoutStopTokenConst<T, FunctionT> || ExecuteWithStopTokenConst<T, FunctionT>;
   }  // namespace detail
 
   /**
@@ -278,6 +302,16 @@ namespace display_device {
       else {
         return exec_fn(*m_iface);
       }
+    }
+
+    /**
+     * @brief A const variant of the `execute` method. See non-const variant for details.
+     */
+    template <class FunctionT>
+      requires detail::ExecuteCallbackLikeConst<T, FunctionT>
+    auto
+    execute(FunctionT exec_fn) const {
+      return const_cast<RetryScheduler *>(this)->execute(std::forward<FunctionT>(exec_fn));
     }
 
     /**

--- a/src/common/include/display_device/retry_scheduler.h
+++ b/src/common/include/display_device/retry_scheduler.h
@@ -311,7 +311,7 @@ namespace display_device {
       requires detail::ExecuteCallbackLikeConst<T, FunctionT>
     auto
     execute(FunctionT exec_fn) const {
-      return const_cast<RetryScheduler *>(this)->execute(std::forward<FunctionT>(exec_fn));
+      return const_cast<RetryScheduler *>(this)->execute(exec_fn);
     }
 
     /**

--- a/tests/unit/general/test_retry_scheduler.cpp
+++ b/tests/unit/general/test_retry_scheduler.cpp
@@ -336,13 +336,13 @@ TEST_F_S(Schedule, ExceptionThrown, DuringScheduledCall) {
 }
 
 TEST_F_S(Execute, NonConst, NullptrCallbackProvided) {
-  EXPECT_THAT([&]() { m_impl.execute(std::function<void(TestIface &)> {}); },
+  EXPECT_THAT([this]() { auto &non_const_impl { m_impl }; non_const_impl.execute(std::function<void(TestIface &)> {}); },
     ThrowsMessage<std::logic_error>(HasSubstr("Empty callback function provided in RetryScheduler::execute!")));
 }
 
 TEST_F_S(Execute, Const, NullptrCallbackProvided) {
   // Note: this test verifies that non-const method is invoked from const method.
-  EXPECT_THAT([&]() { m_impl.execute(std::function<void(TestIface &)> {}); },
+  EXPECT_THAT([this]() { auto &const_impl { m_impl }; const_impl.execute(std::function<void(TestIface &)> {}); },
     ThrowsMessage<std::logic_error>(HasSubstr("Empty callback function provided in RetryScheduler::execute!")));
 }
 

--- a/tests/unit/general/test_retry_scheduler.cpp
+++ b/tests/unit/general/test_retry_scheduler.cpp
@@ -462,8 +462,8 @@ TEST_F_S(Execute, ExceptionThrown, AfterStopToken) {
 }
 
 TEST_F_S(Execute, ConstVsNonConst, WithoutStopToken) {
-  const auto const_callback = [](const TestIface &) {};
-  const auto non_const_callback = [](TestIface &) {};
+  const auto const_callback = [](const TestIface &) { /* noop */ };
+  const auto non_const_callback = [](TestIface &) { /* noop */ };
 
   // Verify that concepts are working as expected
   static_assert(isValidNonConstCallback(const_callback), "Invalid non-const callback");
@@ -482,10 +482,10 @@ TEST_F_S(Execute, ConstVsNonConst, WithoutStopToken) {
 }
 
 TEST_F_S(Execute, ConstVsNonConst, WithStopToken) {
-  const auto const_const_callback = [](const TestIface &, const display_device::SchedulerStopToken &) {};
-  const auto const_non_const_callback = [](const TestIface &, display_device::SchedulerStopToken &) {};
-  const auto non_const_const_callback = [](TestIface &, const display_device::SchedulerStopToken &) {};
-  const auto non_const_non_const_callback = [](TestIface &, display_device::SchedulerStopToken &) {};
+  const auto const_const_callback = [](const TestIface &, const display_device::SchedulerStopToken &) { /* noop */ };
+  const auto const_non_const_callback = [](const TestIface &, display_device::SchedulerStopToken &) { /* noop */ };
+  const auto non_const_const_callback = [](TestIface &, const display_device::SchedulerStopToken &) { /* noop */ };
+  const auto non_const_non_const_callback = [](TestIface &, display_device::SchedulerStopToken &) { /* noop */ };
 
   // Verify that concepts are working as expected
   static_assert(isValidNonConstCallback(const_const_callback), "Invalid non-const callback");

--- a/tests/unit/general/test_retry_scheduler.cpp
+++ b/tests/unit/general/test_retry_scheduler.cpp
@@ -16,6 +16,26 @@ namespace {
     std::vector<int> m_durations;
   };
 
+  template <class FunctionT>
+  constexpr bool
+  isValidNonConstCallback(FunctionT) {
+    using namespace display_device::detail;
+    if constexpr (ExecuteCallbackLike<TestIface, FunctionT>) {
+      return true;
+    }
+    return false;
+  }
+
+  template <class FunctionT>
+  constexpr bool
+  isValidConstCallback(FunctionT) {
+    using namespace display_device::detail;
+    if constexpr (ExecuteCallbackLikeConst<TestIface, FunctionT>) {
+      return true;
+    }
+    return false;
+  }
+
   // Test fixture(s) for this file
   class RetrySchedulerTest: public BaseTest {
   public:
@@ -315,7 +335,13 @@ TEST_F_S(Schedule, ExceptionThrown, DuringScheduledCall) {
   m_impl.stop();
 }
 
-TEST_F_S(Execute, NullptrCallbackProvided) {
+TEST_F_S(Execute, NonConst, NullptrCallbackProvided) {
+  EXPECT_THAT([&]() { m_impl.execute(std::function<void(TestIface &)> {}); },
+    ThrowsMessage<std::logic_error>(HasSubstr("Empty callback function provided in RetryScheduler::execute!")));
+}
+
+TEST_F_S(Execute, Const, NullptrCallbackProvided) {
+  // Note: this test verifies that non-const method is invoked from const method.
   EXPECT_THAT([&]() { m_impl.execute(std::function<void(TestIface &)> {}); },
     ThrowsMessage<std::logic_error>(HasSubstr("Empty callback function provided in RetryScheduler::execute!")));
 }
@@ -433,6 +459,54 @@ TEST_F_S(Execute, ExceptionThrown, AfterStopToken) {
     ThrowsMessage<std::runtime_error>(HasSubstr("Get rekt!")));
 
   EXPECT_FALSE(m_impl.isScheduled());
+}
+
+TEST_F_S(Execute, ConstVsNonConst, WithoutStopToken) {
+  const auto const_callback = [](const TestIface &) {};
+  const auto non_const_callback = [](TestIface &) {};
+
+  // Verify that concepts are working as expected
+  static_assert(isValidNonConstCallback(const_callback), "Invalid non-const callback");
+  static_assert(isValidNonConstCallback(non_const_callback), "Invalid non-const callback");
+  static_assert(isValidConstCallback(const_callback), "Invalid const callback");
+  static_assert(!isValidConstCallback(non_const_callback), "Invalid const callback");
+
+  // Verify it compiles with non-const
+  auto &non_const_impl { m_impl };
+  non_const_impl.execute(const_callback);
+  non_const_impl.execute(non_const_callback);
+
+  // Verify it compiles with const
+  const auto &const_impl { m_impl };
+  const_impl.execute(const_callback);
+}
+
+TEST_F_S(Execute, ConstVsNonConst, WithStopToken) {
+  const auto const_const_callback = [](const TestIface &, const display_device::SchedulerStopToken &) {};
+  const auto const_non_const_callback = [](const TestIface &, display_device::SchedulerStopToken &) {};
+  const auto non_const_const_callback = [](TestIface &, const display_device::SchedulerStopToken &) {};
+  const auto non_const_non_const_callback = [](TestIface &, display_device::SchedulerStopToken &) {};
+
+  // Verify that concepts are working as expected
+  static_assert(isValidNonConstCallback(const_const_callback), "Invalid non-const callback");
+  static_assert(isValidNonConstCallback(const_non_const_callback), "Invalid non-const callback");
+  static_assert(isValidNonConstCallback(non_const_const_callback), "Invalid non-const callback");
+  static_assert(isValidNonConstCallback(non_const_non_const_callback), "Invalid non-const callback");
+  static_assert(isValidConstCallback(const_const_callback), "Invalid const callback");
+  static_assert(!isValidConstCallback(const_non_const_callback), "Invalid const callback");
+  static_assert(!isValidConstCallback(non_const_const_callback), "Invalid const callback");
+  static_assert(!isValidConstCallback(non_const_non_const_callback), "Invalid const callback");
+
+  // Verify it compiles with non-const
+  auto &non_const_impl { m_impl };
+  non_const_impl.execute(const_const_callback);
+  non_const_impl.execute(const_non_const_callback);
+  non_const_impl.execute(non_const_const_callback);
+  non_const_impl.execute(non_const_non_const_callback);
+
+  // Verify it compiles with const
+  const auto &const_impl { m_impl };
+  const_impl.execute(const_const_callback);
 }
 
 TEST_F_S(Stop) {


### PR DESCRIPTION
## Description
Adds a const variant of RetryScheduler::execute...

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
