### PR TITLE
fix: topology not always reverted back after reverting settings

### DIFF
--- a/src/windows/include/display_device/windows/settings_manager.h
+++ b/src/windows/include/display_device/windows/settings_manager.h
@@ -105,13 +105,14 @@ namespace display_device {
     /**
      * @brief Try to revert the modified settings.
      * @param current_topology Topology before this method is called.
-     * @param system_settings_touched Inticates whether a "write" operation could have been performed on the OS.
+     * @param system_settings_touched Indicates whether a "write" operation could have been performed on the OS.
+     * @param switched_topology [Optional] Indicates whether the current topology was switched to revert settings.
      * @returns True on success, false otherwise.
      * @warning The method assumes that the caller will ensure restoring the topology
      *          in case of a failure!
      */
     [[nodiscard]] bool
-    revertModifiedSettings(const ActiveTopology &current_topology, bool &system_settings_touched);
+    revertModifiedSettings(const ActiveTopology &current_topology, bool &system_settings_touched, bool* switched_topology = nullptr);
 
     std::shared_ptr<WinDisplayDeviceInterface> m_dd_api;
     std::shared_ptr<AudioContextInterface> m_audio_context_api;

--- a/src/windows/include/display_device/windows/settings_manager.h
+++ b/src/windows/include/display_device/windows/settings_manager.h
@@ -112,7 +112,7 @@ namespace display_device {
      *          in case of a failure!
      */
     [[nodiscard]] bool
-    revertModifiedSettings(const ActiveTopology &current_topology, bool &system_settings_touched, bool* switched_topology = nullptr);
+    revertModifiedSettings(const ActiveTopology &current_topology, bool &system_settings_touched, bool *switched_topology = nullptr);
 
     std::shared_ptr<WinDisplayDeviceInterface> m_dd_api;
     std::shared_ptr<AudioContextInterface> m_audio_context_api;


### PR DESCRIPTION
## Description
If the user manually switches back to the initial display topology and then reverts the settings, we would switch to the modified topology to undo stuff, but then never switch back to the initial topology matched the current one.

We are now smart enough to actually go "hmm, if current_topology == initial_topology, but then I switch to modified_topology, then current_topology != initial_topology after that! Me thinks thou should switch back'o to the ini_topo!" (yes, I'm losing sanity here)...

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
