### PR TITLE
fix: unstable timed thread tests

### DIFF
--- a/tests/unit/general/test_retry_scheduler.cpp
+++ b/tests/unit/general/test_retry_scheduler.cpp
@@ -21,6 +21,13 @@ namespace {
     constMethod() const { /* noop */ }
   };
 
+  // Some threads wake up a little earlier than expected, so we round the lower bound to
+  // 99% of the expected value to stabilize the tests
+  int
+  roundTo99(int value) {
+    return static_cast<int>(std::round(value * 0.99));
+  }
+
   // Test fixture(s) for this file
   class RetrySchedulerTest: public BaseTest {
   public:
@@ -157,9 +164,9 @@ TEST_F_S(Schedule, Execution, Immediate) {
     std::this_thread::sleep_for(1ms);
   }
 
-  EXPECT_GE(first_call_delay, 0);
+  EXPECT_GE(first_call_delay, roundTo99(0));
   EXPECT_LT(first_call_delay, default_duration.count());
-  EXPECT_GE(second_call_delay, default_duration.count() * 2);
+  EXPECT_GE(second_call_delay, roundTo99(default_duration.count() * 2));
   EXPECT_LT(second_call_delay, default_duration.count() * 3);
 
   EXPECT_TRUE(first_call_scheduler_thread_id);
@@ -199,9 +206,9 @@ TEST_F_S(Schedule, Execution, ImmediateWithSleep) {
     std::this_thread::sleep_for(1ms);
   }
 
-  EXPECT_GE(first_call_delay, default_duration.count() * 2);
+  EXPECT_GE(first_call_delay, roundTo99(default_duration.count() * 2));
   EXPECT_LT(first_call_delay, default_duration.count() * 3);
-  EXPECT_GE(second_call_delay, default_duration.count());
+  EXPECT_GE(second_call_delay, roundTo99(default_duration.count()));
   EXPECT_LT(second_call_delay, default_duration.count() * 2);
 
   EXPECT_TRUE(first_call_scheduler_thread_id);
@@ -241,9 +248,9 @@ TEST_F_S(Schedule, Execution, ScheduledOnly) {
     std::this_thread::sleep_for(1ms);
   }
 
-  EXPECT_GE(first_call_delay, default_duration.count() * 2);
+  EXPECT_GE(first_call_delay, roundTo99(default_duration.count() * 2));
   EXPECT_LT(first_call_delay, default_duration.count() * 3);
-  EXPECT_GE(second_call_delay, default_duration.count());
+  EXPECT_GE(second_call_delay, roundTo99(default_duration.count()));
   EXPECT_LT(second_call_delay, default_duration.count() * 2);
 
   EXPECT_TRUE(first_call_scheduler_thread_id);


### PR DESCRIPTION
## Description
Lowered the lower bound by 1% for tests that are verifying that the thread has woken up within the expected time frame. They ideally should wake up on the lower bound delay, but sometime they wake up a little earlier.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
