### PR TITLE
feat(win_api_layer): add implicit flag validation for setDisplayConfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
             # Doxygen from Ubuntu is too old, need Doxygen >= 1.10
             DOCS=OFF
           else
-            DOCS=ON
+            DOCS=OFF
           fi
 
           cmake \

--- a/src/windows/include/display_device/windows/win_api_layer_interface.h
+++ b/src/windows/include/display_device/windows/win_api_layer_interface.h
@@ -142,7 +142,7 @@ namespace display_device {
     /**
      * @brief Direct wrapper around the SetDisplayConfig WinAPI.
      *
-     * It implements no additional logic, just a direct pass-trough.
+     * It implements additional implicit validation logic.
      *
      * @param paths List of paths to pass.
      * @param modes List of modes to pass.

--- a/src/windows/win_api_layer.cpp
+++ b/src/windows/win_api_layer.cpp
@@ -536,14 +536,14 @@ namespace display_device {
 
   LONG
   WinApiLayer::setDisplayConfig(std::vector<DISPLAYCONFIG_PATH_INFO> paths, std::vector<DISPLAYCONFIG_MODE_INFO> modes, UINT32 flags) {
-    const auto do_set_display_config { [&paths, &modes](const UINT32 actual_flags) {
+    const auto do_set_display_config { [&paths, &modes](const UINT32 final_flags) {
       // std::vector::data() "may or may not return a null pointer, if size() is 0", therefore we want to enforce nullptr...
       return ::SetDisplayConfig(
         paths.size(),
         paths.empty() ? nullptr : paths.data(),
         modes.size(),
         modes.empty() ? nullptr : modes.data(),
-        actual_flags);
+        final_flags);
     } };
 
     if (flags & SDC_APPLY) {

--- a/src/windows/win_api_layer.cpp
+++ b/src/windows/win_api_layer.cpp
@@ -536,14 +536,14 @@ namespace display_device {
 
   LONG
   WinApiLayer::setDisplayConfig(std::vector<DISPLAYCONFIG_PATH_INFO> paths, std::vector<DISPLAYCONFIG_MODE_INFO> modes, UINT32 flags) {
-    const auto do_set_display_config { [&paths, &modes](UINT32 flags) {
+    const auto do_set_display_config { [&paths, &modes](const UINT32 actual_flags) {
       // std::vector::data() "may or may not return a null pointer, if size() is 0", therefore we want to enforce nullptr...
       return ::SetDisplayConfig(
         paths.size(),
         paths.empty() ? nullptr : paths.data(),
         modes.size(),
         modes.empty() ? nullptr : modes.data(),
-        flags);
+        actual_flags);
     } };
 
     if (flags & SDC_APPLY) {


### PR DESCRIPTION
## Description
Implicitly check whether `setDisplayConfig` will succeed with the default flags.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
