### PR TITLE
fix(enumAvailableDevices): exception when enumerating

### DIFF
--- a/src/windows/win_display_device_general.cpp
+++ b/src/windows/win_display_device_general.cpp
@@ -42,7 +42,8 @@ namespace display_device {
     }
 
     for (const auto &[device_id, data] : source_data) {
-      const auto source_id_index {data.m_active_source.value_or(0)};
+      // In case we have no active source, we will take the first available source id
+      const auto source_id_index {data.m_active_source.value_or(data.m_source_id_to_path_index.begin()->first)};
       const auto &best_path {display_data->m_paths.at(data.m_source_id_to_path_index.at(source_id_index))};
       const auto friendly_name {m_w_api->getFriendlyName(best_path)};
       const bool is_active {win_utils::isActive(best_path)};

--- a/tests/unit/windows/utils/mock_win_api_layer.cpp
+++ b/tests/unit/windows/utils/mock_win_api_layer.cpp
@@ -11,7 +11,7 @@ namespace {
       data.m_paths.back().flags = DISPLAYCONFIG_PATH_ACTIVE;
       data.m_paths.back().sourceInfo.sourceModeInfoIdx = data.m_modes.size();
       data.m_paths.back().sourceInfo.adapterId = {1, 1};
-      data.m_paths.back().sourceInfo.id = 0;
+      data.m_paths.back().sourceInfo.id = 1;
       data.m_paths.back().targetInfo.targetAvailable = TRUE;
       data.m_paths.back().targetInfo.refreshRate = {120, 1};
 
@@ -29,7 +29,7 @@ namespace {
       data.m_paths.back().flags = DISPLAYCONFIG_PATH_ACTIVE;
       data.m_paths.back().sourceInfo.sourceModeInfoIdx = data.m_modes.size();
       data.m_paths.back().sourceInfo.adapterId = {2, 2};
-      data.m_paths.back().sourceInfo.id = 0;
+      data.m_paths.back().sourceInfo.id = 2;
       data.m_paths.back().targetInfo.targetAvailable = TRUE;
       data.m_paths.back().targetInfo.refreshRate = {119995, 1000};
 
@@ -45,7 +45,7 @@ namespace {
         data.m_paths.back().flags = DISPLAYCONFIG_PATH_ACTIVE;
         data.m_paths.back().sourceInfo.sourceModeInfoIdx = data.m_modes.size();
         data.m_paths.back().sourceInfo.adapterId = {3, 3};
-        data.m_paths.back().sourceInfo.id = 0;
+        data.m_paths.back().sourceInfo.id = 3;
         data.m_paths.back().targetInfo.targetAvailable = TRUE;
         data.m_paths.back().targetInfo.refreshRate = {60, 1};
 
@@ -64,7 +64,7 @@ namespace {
       data.m_paths.back().flags = DISPLAYCONFIG_PATH_ACTIVE;
       data.m_paths.back().sourceInfo.sourceModeInfoIdx = data.m_modes.size();
       data.m_paths.back().sourceInfo.adapterId = {4, 4};
-      data.m_paths.back().sourceInfo.id = 0;
+      data.m_paths.back().sourceInfo.id = 4;
       data.m_paths.back().targetInfo.targetAvailable = TRUE;
       data.m_paths.back().targetInfo.refreshRate = {90, 1};
 


### PR DESCRIPTION
## Description
Fixed a stupid assumption that source id `0` is always available, instead we now fallback to first source id.

The test data set was also updated to non-zero ids, which reproduced the crash, however with the fix all tests are green again.

### Issues Fixed or Closed
Should fix the Sunshine crash in https://github.com/LizardByte/Sunshine/issues/3770

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
