### PR TITLE
fix(build): Disable test for windows arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     option(BUILD_DOCS "Build documentation" ON)
     option(BUILD_TESTS "Build tests" ON)
+
+    # CLANGARM64 does not have libatomic which used by googletest, disable it
+    if(MINGW AND CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64")
+        set(BUILD_TESTS OFF CACHE BOOL "Build tests" FORCE)
+    endif()
 endif()
 
 #


### PR DESCRIPTION

## Description
CLANGARM64 does not have libatomic which used by googletest, disable it

This does not completely disable linking against libatomic, as Boost's uuid does not disable it on Windows Arm64
Link: https://github.com/boostorg/uuid/pull/176

### Screenshot
None


### Issues Fixed or Closed
None

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
