### PR TITLE
fix: remove redundant const qualifier on reference type

### DIFF
--- a/src/windows/settings_utils.cpp
+++ b/src/windows/settings_utils.cpp
@@ -42,7 +42,7 @@ namespace display_device::win_utils {
      * const auto primary_only_ids { getDeviceIds(devices, primaryOnlyDevices) };
      * @examples_end
      */
-    std::set<std::string> getDeviceIds(const EnumeratedDeviceList &devices, const std::add_lvalue_reference_t<bool(const EnumeratedDevice &)> &predicate) {
+    std::set<std::string> getDeviceIds(const EnumeratedDeviceList &devices, std::add_lvalue_reference_t<bool(const EnumeratedDevice &)> &predicate) {
       std::set<std::string> device_ids;
       for (const auto &device : devices) {
         if (predicate(device)) {


### PR DESCRIPTION

<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
CLANGARM64 emits -Wignored-reference-qualifiers
warning because 'const' on a reference type has no effect.

Removing it cleans up the build output and improves compatibility with LLVM toolchains.

## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [x] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
