### PR TITLE
fix(windows): recover display layout after undocking

### DIFF
--- a/src/common/include/display_device/types.h
+++ b/src/common/include/display_device/types.h
@@ -195,6 +195,7 @@ namespace display_device {
     std::string m_friendly_name {};  ///< A human-readable name for the device.
     std::optional<EdidData> m_edid {};  ///< Some basic parsed EDID data.
     std::optional<Info> m_info {};  ///< Additional information about an active display device.
+    bool m_is_internal {};  ///< Positively identified built-in panel; false also covers unknown connectors.
 
     /**
      * @brief Comparator for strict equality.

--- a/src/common/json_serializer.cpp
+++ b/src/common/json_serializer.cpp
@@ -21,6 +21,11 @@ namespace display_device {
   DD_JSON_DEFINE_SERIALIZE_STRUCT(EdidData, manufacturer_id, product_code, serial_number)
   DD_JSON_DEFINE_SERIALIZE_STRUCT(EnumeratedDevice::Info, resolution, resolution_scale, refresh_rate, primary, origin_point, hdr_state)
 
+  /**
+   * @brief Serialize an enumerated display, including its internal-panel classification.
+   * @param nlohmann_json_j JSON output object.
+   * @param nlohmann_json_t Device to serialize.
+   */
   void to_json(nlohmann::json &nlohmann_json_j, const EnumeratedDevice &nlohmann_json_t) {
     DD_JSON_TO(device_id)
     DD_JSON_TO(display_name)
@@ -30,6 +35,11 @@ namespace display_device {
     DD_JSON_TO(is_internal)
   }
 
+  /**
+   * @brief Deserialize a display, treating missing internal-panel information as unknown.
+   * @param nlohmann_json_j JSON input object.
+   * @param nlohmann_json_t Device to populate.
+   */
   void from_json(const nlohmann::json &nlohmann_json_j, EnumeratedDevice &nlohmann_json_t) {
     DD_JSON_FROM(device_id)
     DD_JSON_FROM(display_name)

--- a/src/common/json_serializer.cpp
+++ b/src/common/json_serializer.cpp
@@ -20,6 +20,23 @@ namespace display_device {
   DD_JSON_DEFINE_SERIALIZE_STRUCT(Point, x, y)
   DD_JSON_DEFINE_SERIALIZE_STRUCT(EdidData, manufacturer_id, product_code, serial_number)
   DD_JSON_DEFINE_SERIALIZE_STRUCT(EnumeratedDevice::Info, resolution, resolution_scale, refresh_rate, primary, origin_point, hdr_state)
-  DD_JSON_DEFINE_SERIALIZE_STRUCT(EnumeratedDevice, device_id, display_name, friendly_name, edid, info)
+
+  void to_json(nlohmann::json &nlohmann_json_j, const EnumeratedDevice &nlohmann_json_t) {
+    DD_JSON_TO(device_id)
+    DD_JSON_TO(display_name)
+    DD_JSON_TO(friendly_name)
+    DD_JSON_TO(edid)
+    DD_JSON_TO(info)
+    DD_JSON_TO(is_internal)
+  }
+
+  void from_json(const nlohmann::json &nlohmann_json_j, EnumeratedDevice &nlohmann_json_t) {
+    DD_JSON_FROM(device_id)
+    DD_JSON_FROM(display_name)
+    DD_JSON_FROM(friendly_name)
+    DD_JSON_FROM(edid)
+    DD_JSON_FROM(info)
+    nlohmann_json_t.m_is_internal = nlohmann_json_j.value("is_internal", false);
+  }
   DD_JSON_DEFINE_SERIALIZE_STRUCT(SingleDisplayConfiguration, device_id, device_prep, resolution, refresh_rate, hdr_state)
 }  // namespace display_device

--- a/src/windows/include/display_device/windows/settings_manager.h
+++ b/src/windows/include/display_device/windows/settings_manager.h
@@ -152,6 +152,8 @@ namespace display_device {
      * @brief Recover to surviving original displays or a built-in panel after an undock.
      * Only devices activated by this session may be removed. The original recovery
      * record remains intact on failure; a visible replacement is verified first.
+     * @param current_topology Active topology before attempting to restore the saved layout.
+     * @return True when the replacement topology has been applied and verified.
      */
     [[nodiscard]] bool recoverMissingTopology(const ActiveTopology &current_topology);
 

--- a/src/windows/include/display_device/windows/settings_manager.h
+++ b/src/windows/include/display_device/windows/settings_manager.h
@@ -148,6 +148,13 @@ namespace display_device {
      */
     [[nodiscard]] RevertResult revertModifiedPrimaryDevice(const SingleDisplayConfigState::Modified &modified_state, DdGuardFn &guard_fn, bool &system_settings_touched);
 
+    /**
+     * @brief Recover to surviving original displays or a built-in panel after an undock.
+     * Only devices activated by this session may be removed. The original recovery
+     * record remains intact on failure; a visible replacement is verified first.
+     */
+    [[nodiscard]] bool recoverMissingTopology(const ActiveTopology &current_topology);
+
   private:
     std::shared_ptr<WinDisplayDeviceInterface> m_dd_api;
     std::shared_ptr<AudioContextInterface> m_audio_context_api;

--- a/src/windows/include/display_device/windows/win_display_device.h
+++ b/src/windows/include/display_device/windows/win_display_device.h
@@ -19,9 +19,10 @@ namespace display_device {
   public:
     /**
      * Default constructor for the class.
+     * @param save_to_database Whether CCD changes update Windows' saved display layout.
      * @param w_api A pointer to the Windows API layer. Will throw on nullptr!
      */
-    explicit WinDisplayDevice(std::shared_ptr<WinApiLayerInterface> w_api);
+    explicit WinDisplayDevice(std::shared_ptr<WinApiLayerInterface> w_api, bool save_to_database = true);
 
     /**
      * @copydoc WinDisplayDeviceInterface::isApiAccessAvailable
@@ -90,5 +91,6 @@ namespace display_device {
 
   private:
     std::shared_ptr<WinApiLayerInterface> m_w_api;
+    bool m_save_to_database;
   };
 }  // namespace display_device

--- a/src/windows/settings_manager_revert.cpp
+++ b/src/windows/settings_manager_revert.cpp
@@ -22,6 +22,28 @@ namespace display_device {
     void noopFn() {
       // Intentionally empty guard callback.
     }
+
+    /**
+     * @brief Append available groups without reactivating stream-only outputs or duplicating devices.
+     * @param topology Groups to consider, in priority order.
+     * @param available Currently enumerated device IDs.
+     * @param activated Device IDs activated only for the stream.
+     * @param target Recovery topology to extend.
+     * @param included IDs already included in the recovery topology.
+     */
+    void appendRecoveryGroups(const ActiveTopology &topology, const StringSet &available, const StringSet &activated, ActiveTopology &target, StringSet &included) {
+      for (const auto &group : topology) {
+        std::vector<std::string> remaining;
+        for (const auto &id : group) {
+          if (available.contains(id) && !activated.contains(id) && included.insert(id).second) {
+            remaining.push_back(id);
+          }
+        }
+        if (!remaining.empty()) {
+          target.push_back(std::move(remaining));
+        }
+      }
+    }
   }  // namespace
 
   SettingsManager::RevertResult SettingsManager::revertSettings() {
@@ -111,7 +133,7 @@ namespace display_device {
     for (const auto &device : devices) {
       available.insert(device.m_device_id);
     }
-    if (available.empty() || std::ranges::all_of(initial, [&](const auto &id) {
+    if (available.empty() || std::ranges::all_of(initial, [&available](const auto &id) {
           return available.contains(id);
         })) {
       // An API failure with unchanged hardware must not discard the original state.
@@ -122,25 +144,12 @@ namespace display_device {
     std::ranges::set_difference(modified, initial, std::inserter(activated, activated.end()));
     ActiveTopology target;
     StringSet included;
-    const auto append = [&](const ActiveTopology &topology) {
-      for (const auto &group : topology) {
-        std::vector<std::string> remaining;
-        for (const auto &id : group) {
-          if (available.contains(id) && !activated.contains(id) && included.insert(id).second) {
-            remaining.push_back(id);
-          }
-        }
-        if (!remaining.empty()) {
-          target.push_back(std::move(remaining));
-        }
-      }
-    };
-    append(state.m_initial.m_topology);
+    appendRecoveryGroups(state.m_initial.m_topology, available, activated, target, included);
     if (target.empty()) {
       // An arbitrary virtual/unknown output is not proof of a usable laptop screen.
       for (const auto &device : devices) {
         if (device.m_is_internal && !activated.contains(device.m_device_id)) {
-          append({{device.m_device_id}});
+          appendRecoveryGroups({{device.m_device_id}}, available, activated, target, included);
           break;
         }
       }
@@ -149,7 +158,7 @@ namespace display_device {
       return false;  // Closed lid and no original display: retain pending recovery.
     }
     const auto replacements {win_utils::flattenTopology(target)};
-    append(current_topology);  // Preserve unrelated displays activated by the user.
+    appendRecoveryGroups(current_topology, available, activated, target, included);  // Preserve unrelated displays activated by the user.
 
     // First activate the replacement without switching off the current output.
     ActiveTopology staged {current_topology};
@@ -163,7 +172,7 @@ namespace display_device {
       return false;
     }
     const auto active {win_utils::flattenTopology(m_dd_api->getCurrentTopology())};
-    if (!std::ranges::all_of(replacements, [&](const auto &id) {
+    if (!std::ranges::all_of(replacements, [&active](const auto &id) {
           return active.contains(id);
         })) {
       return false;

--- a/src/windows/settings_manager_revert.cpp
+++ b/src/windows/settings_manager_revert.cpp
@@ -6,6 +6,7 @@
 #include "display_device/windows/settings_manager.h"
 
 // system includes
+#include <algorithm>
 #include <boost/scope/scope_exit.hpp>
 
 // local includes
@@ -82,7 +83,9 @@ namespace display_device {
     if (need_to_switch_topology && !m_dd_api->setTopology(cached_state->m_initial.m_topology)) {
       DD_LOG(error) << "Failed to change topology to:\n"
                     << toJson(cached_state->m_initial.m_topology);
-      return RevertResult::SwitchingTopologyFailed;
+      if (!recoverMissingTopology(current_topology)) {
+        return RevertResult::SwitchingTopologyFailed;
+      }
     }
 
     if (!m_persistence_state->persistState(std::nullopt)) {
@@ -97,6 +100,80 @@ namespace display_device {
     // Disable guards
     topology_prep_guard.set_active(false);
     return RevertResult::Ok;
+  }
+
+  bool SettingsManager::recoverMissingTopology(const ActiveTopology &current_topology) {
+    const auto &state {*m_persistence_state->getState()};
+    const auto initial {win_utils::flattenTopology(state.m_initial.m_topology)};
+    const auto modified {win_utils::flattenTopology(state.m_modified.m_topology)};
+    const auto devices {m_dd_api->enumAvailableDevices()};
+    StringSet available;
+    for (const auto &device : devices) {
+      available.insert(device.m_device_id);
+    }
+    if (available.empty() || std::ranges::all_of(initial, [&](const auto &id) {
+          return available.contains(id);
+        })) {
+      // An API failure with unchanged hardware must not discard the original state.
+      return false;
+    }
+
+    StringSet activated;
+    std::ranges::set_difference(modified, initial, std::inserter(activated, activated.end()));
+    ActiveTopology target;
+    StringSet included;
+    const auto append = [&](const ActiveTopology &topology) {
+      for (const auto &group : topology) {
+        std::vector<std::string> remaining;
+        for (const auto &id : group) {
+          if (available.contains(id) && !activated.contains(id) && included.insert(id).second) {
+            remaining.push_back(id);
+          }
+        }
+        if (!remaining.empty()) {
+          target.push_back(std::move(remaining));
+        }
+      }
+    };
+    append(state.m_initial.m_topology);
+    if (target.empty()) {
+      // An arbitrary virtual/unknown output is not proof of a usable laptop screen.
+      for (const auto &device : devices) {
+        if (device.m_is_internal && !activated.contains(device.m_device_id)) {
+          append({{device.m_device_id}});
+          break;
+        }
+      }
+    }
+    if (target.empty()) {
+      return false;  // Closed lid and no original display: retain pending recovery.
+    }
+    const auto replacements {win_utils::flattenTopology(target)};
+    append(current_topology);  // Preserve unrelated displays activated by the user.
+
+    // First activate the replacement without switching off the current output.
+    ActiveTopology staged {current_topology};
+    auto staged_ids {win_utils::flattenTopology(staged)};
+    for (const auto &id : included) {
+      if (staged_ids.insert(id).second) {
+        staged.push_back({id});
+      }
+    }
+    if (!m_dd_api->setTopology(staged)) {
+      return false;
+    }
+    const auto active {win_utils::flattenTopology(m_dd_api->getCurrentTopology())};
+    if (!std::ranges::all_of(replacements, [&](const auto &id) {
+          return active.contains(id);
+        })) {
+      return false;
+    }
+    if (!m_dd_api->setTopology(target) || !m_dd_api->isTopologyTheSame(m_dd_api->getCurrentTopology(), target)) {
+      return false;
+    }
+    DD_LOG(info) << "Recovered display topology after original devices disappeared:\n"
+                 << toJson(target);
+    return true;
   }
 
   SettingsManager::RevertResult SettingsManager::revertModifiedHdrStates(const SingleDisplayConfigState::Modified &modified_state, DdGuardFn &guard_fn, bool &system_settings_touched) {

--- a/src/windows/win_display_device_general.cpp
+++ b/src/windows/win_display_device_general.cpp
@@ -13,8 +13,9 @@
 #include "display_device/windows/win_api_utils.h"
 
 namespace display_device {
-  WinDisplayDevice::WinDisplayDevice(std::shared_ptr<WinApiLayerInterface> w_api):
-      m_w_api {std::move(w_api)} {
+  WinDisplayDevice::WinDisplayDevice(std::shared_ptr<WinApiLayerInterface> w_api, bool save_to_database):
+      m_w_api {std::move(w_api)},
+      m_save_to_database {save_to_database} {
     if (!m_w_api) {
       throw std::invalid_argument {"Nullptr provided for WinApiLayerInterface in WinDisplayDevice!"};
     }
@@ -53,6 +54,8 @@ namespace display_device {
       const auto source_mode {is_active ? win_utils::getSourceMode(win_utils::getSourceIndex(best_path, display_data->m_modes), display_data->m_modes) : nullptr};
       const auto display_name {is_active ? m_w_api->getDisplayName(best_path) : std::string {}};  // Inactive devices can have multiple display names, so it's just meaningless use any
       const auto edid {EdidData::parse(m_w_api->getEdid(best_path))};
+      const auto technology {best_path.targetInfo.outputTechnology};
+      const bool is_internal {technology == DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INTERNAL || technology == DISPLAYCONFIG_OUTPUT_TECHNOLOGY_LVDS || technology == DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EMBEDDED || technology == DISPLAYCONFIG_OUTPUT_TECHNOLOGY_UDI_EMBEDDED};
 
       if (is_active && !source_mode) {
         DD_LOG(warning) << "Device " << device_id << " is missing source mode!";
@@ -70,10 +73,10 @@ namespace display_device {
         };
 
         // Keep braced aggregate construction; emplace_back(args...) relies on parenthesized aggregate init, which older libc++ rejects.
-        available_devices.push_back(EnumeratedDevice {device_id, display_name, friendly_name, edid, info});  // NOSONAR(cpp:S6003): Direct emplace_back args fail on older toolchains
+        available_devices.push_back(EnumeratedDevice {device_id, display_name, friendly_name, edid, info, is_internal});  // NOSONAR(cpp:S6003): Direct emplace_back args fail on older toolchains
       } else {
         // Keep braced aggregate construction; emplace_back(args...) relies on parenthesized aggregate init, which older libc++ rejects.
-        available_devices.push_back(EnumeratedDevice {device_id, display_name, friendly_name, edid, std::nullopt});  // NOSONAR(cpp:S6003): Direct emplace_back args fail on older toolchains
+        available_devices.push_back(EnumeratedDevice {device_id, display_name, friendly_name, edid, std::nullopt, is_internal});  // NOSONAR(cpp:S6003): Direct emplace_back args fail on older toolchains
       }
     }
 

--- a/src/windows/win_display_device_modes.cpp
+++ b/src/windows/win_display_device_modes.cpp
@@ -26,7 +26,7 @@ namespace display_device {
     /**
      * @see set_display_modes for a description as this was split off to reduce cognitive complexity.
      */
-    bool doSetModes(WinApiLayerInterface &w_api, const DeviceDisplayModeMap &modes, const Strategy strategy) {
+    bool doSetModes(WinApiLayerInterface &w_api, const DeviceDisplayModeMap &modes, const Strategy strategy, const bool save_to_database) {
       auto display_data {w_api.queryDisplayConfig(QueryType::Active)};
       if (!display_data) {
         // Error already logged
@@ -85,7 +85,7 @@ namespace display_device {
         return true;
       }
 
-      UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_SAVE_TO_DATABASE | SDC_VIRTUAL_MODE_AWARE};
+      UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | (save_to_database ? SDC_SAVE_TO_DATABASE : 0u) | SDC_VIRTUAL_MODE_AWARE};
       if (strategy == Strategy::Relaxed) {
         // It's probably best for Windows to select the "best" display settings for us. However, in case we
         // have custom resolution set in nvidia control panel for example, this flag will prevent successfully applying
@@ -182,7 +182,7 @@ namespace display_device {
       return false;
     }
 
-    if (!doSetModes(*m_w_api, modes, Strategy::Relaxed)) {
+    if (!doSetModes(*m_w_api, modes, Strategy::Relaxed, m_save_to_database)) {
       // Error already logged
       return false;
     }
@@ -219,7 +219,7 @@ namespace display_device {
       // resolution to be selected, we actually need to omit SDC_ALLOW_CHANGES
       // flag.
       DD_LOG(info) << "Failed to change display modes using Windows recommended modes, trying to set modes more strictly!";
-      if (doSetModes(*m_w_api, modes, Strategy::Strict)) {
+      if (doSetModes(*m_w_api, modes, Strategy::Strict, m_save_to_database)) {
         current_modes = getCurrentDisplayModes(device_ids);
         if (!current_modes.empty() && all_modes_match(current_modes)) {
           return true;
@@ -227,7 +227,7 @@ namespace display_device {
       }
     }
 
-    const UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_SAVE_TO_DATABASE | SDC_VIRTUAL_MODE_AWARE};
+    const UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | (m_save_to_database ? SDC_SAVE_TO_DATABASE : 0u) | SDC_VIRTUAL_MODE_AWARE};
     static_cast<void>(m_w_api->setDisplayConfig(original_data->m_paths, original_data->m_modes, flags));  // Return value does not matter as we are trying out best to undo
     DD_LOG(error) << "Failed to set display mode(-s) completely!";
     return false;

--- a/src/windows/win_display_device_primary.cpp
+++ b/src/windows/win_display_device_primary.cpp
@@ -97,7 +97,7 @@ namespace display_device {
       modified_modes.insert(*source_index);
     }
 
-    const UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_SAVE_TO_DATABASE | SDC_VIRTUAL_MODE_AWARE};
+    const UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | (m_save_to_database ? SDC_SAVE_TO_DATABASE : 0u) | SDC_VIRTUAL_MODE_AWARE};
     if (const LONG result {m_w_api->setDisplayConfig(display_data->m_paths, display_data->m_modes, flags)}; result != ERROR_SUCCESS) {
       DD_LOG(error) << m_w_api->getErrorString(result) << " failed to set primary mode for " << device_id << "!";
       return false;

--- a/src/windows/win_display_device_topology.cpp
+++ b/src/windows/win_display_device_topology.cpp
@@ -19,7 +19,7 @@ namespace display_device {
     /**
      * @see set_topology for a description as this was split off to reduce cognitive complexity.
      */
-    bool doSetTopology(WinApiLayerInterface &w_api, const ActiveTopology &new_topology, const PathAndModeData &display_data) {
+    bool doSetTopology(WinApiLayerInterface &w_api, const ActiveTopology &new_topology, const PathAndModeData &display_data, const bool save_to_database) {
       const auto path_data {win_utils::collectSourceDataForMatchingPaths(w_api, display_data.m_paths)};
       if (path_data.empty()) {
         // Error already logged
@@ -30,6 +30,18 @@ namespace display_device {
       if (paths.empty()) {
         // Error already logged
         return false;
+      }
+
+      if (!save_to_database) {
+        // TOPOLOGY_SUPPLIED also changes the remembered topology. Session-only
+        // layouts must use the explicitly temporary supplied-config API path.
+        const UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+        const LONG result {w_api.setDisplayConfig(paths, {}, flags)};
+        if (result != ERROR_SUCCESS) {
+          DD_LOG(error) << w_api.getErrorString(result) << " failed to set temporary topology!";
+          return false;
+        }
+        return true;
       }
 
       UINT32 flags {SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE};
@@ -158,7 +170,7 @@ namespace display_device {
       return false;
     }
 
-    if (doSetTopology(*m_w_api, new_topology, *original_data)) {
+    if (doSetTopology(*m_w_api, new_topology, *original_data, m_save_to_database)) {
       if (const auto updated_topology {getCurrentTopology()}; isTopologyValid(updated_topology)) {
         if (isTopologyTheSame(new_topology, updated_topology)) {
           return true;
@@ -194,7 +206,7 @@ namespace display_device {
       }
 
       // Revert back to the original topology
-      const UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_SAVE_TO_DATABASE | SDC_VIRTUAL_MODE_AWARE};
+      const UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | (m_save_to_database ? SDC_SAVE_TO_DATABASE : 0u) | SDC_VIRTUAL_MODE_AWARE};
       static_cast<void>(m_w_api->setDisplayConfig(original_data->m_paths, original_data->m_modes, flags));  // Return value does not matter as we are trying out best to undo
     }
 

--- a/src/windows/win_display_device_topology.cpp
+++ b/src/windows/win_display_device_topology.cpp
@@ -36,8 +36,7 @@ namespace display_device {
         // TOPOLOGY_SUPPLIED also changes the remembered topology. Session-only
         // layouts must use the explicitly temporary supplied-config API path.
         const UINT32 flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
-        const LONG result {w_api.setDisplayConfig(paths, {}, flags)};
-        if (result != ERROR_SUCCESS) {
+        if (const LONG result {w_api.setDisplayConfig(paths, {}, flags)}; result != ERROR_SUCCESS) {
           DD_LOG(error) << w_api.getErrorString(result) << " failed to set temporary topology!";
           return false;
         }

--- a/tests/unit/general/test_json_converter.cpp
+++ b/tests/unit/general/test_json_converter.cpp
@@ -58,9 +58,9 @@ TEST_F_S(EnumeratedDevice) {
   const auto item_1 {makeEnumeratedDeviceOne()};
   const auto item_2 {makeEnumeratedDeviceTwo()};
 
-  executeTestCase(display_device::EnumeratedDevice {}, R"({"device_id":"","display_name":"","edid":null,"friendly_name":"","info":null})");
-  executeTestCase(item_1, R"({"device_id":"ID_1","display_name":"NAME_2","edid":null,"friendly_name":"FU_NAME_3","info":{"hdr_state":"Enabled","origin_point":{"x":1,"y":2},"primary":false,"refresh_rate":{"type":"double","value":119.9554},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"rational","value":{"denominator":100,"numerator":175}}}})");
-  executeTestCase(item_2, R"({"device_id":"ID_2","display_name":"NAME_2","edid":{"manufacturer_id":"","product_code":"","serial_number":0},"friendly_name":"FU_NAME_2","info":{"hdr_state":"Disabled","origin_point":{"x":0,"y":0},"primary":true,"refresh_rate":{"type":"rational","value":{"denominator":10000,"numerator":1199554}},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"double","value":1.75}}})");
+  executeTestCase(display_device::EnumeratedDevice {}, R"({"device_id":"","display_name":"","edid":null,"friendly_name":"","info":null,"is_internal":false})");
+  executeTestCase(item_1, R"({"device_id":"ID_1","display_name":"NAME_2","edid":null,"friendly_name":"FU_NAME_3","info":{"hdr_state":"Enabled","origin_point":{"x":1,"y":2},"primary":false,"refresh_rate":{"type":"double","value":119.9554},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"rational","value":{"denominator":100,"numerator":175}}},"is_internal":false})");
+  executeTestCase(item_2, R"({"device_id":"ID_2","display_name":"NAME_2","edid":{"manufacturer_id":"","product_code":"","serial_number":0},"friendly_name":"FU_NAME_2","info":{"hdr_state":"Disabled","origin_point":{"x":0,"y":0},"primary":true,"refresh_rate":{"type":"rational","value":{"denominator":10000,"numerator":1199554}},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"double","value":1.75}},"is_internal":false})");
   executeInvalidJsonTestCase<display_device::EnumeratedDevice>();
   executeFromJsonFailureTestCase<display_device::EnumeratedDevice>(R"({})");
   executeFromJsonFailureTestCase<display_device::EnumeratedDevice>(R"({"device_id":"","display_name":"","edid":null,"friendly_name":"","info":{"hdr_state":null,"origin_point":{"x":0,"y":0},"primary":false,"refresh_rate":{"type":"unknown","value":0},"resolution":{"height":0,"width":0},"resolution_scale":{"type":"double","value":1.0}}})");
@@ -73,9 +73,9 @@ TEST_F_S(EnumeratedDeviceList) {
   display_device::EnumeratedDevice item_3 {};
 
   executeTestCase(display_device::EnumeratedDeviceList {}, R"([])");
-  executeTestCase(display_device::EnumeratedDeviceList {item_1, item_2, item_3}, R"([{"device_id":"ID_1","display_name":"NAME_2","edid":null,"friendly_name":"FU_NAME_3","info":{"hdr_state":"Enabled","origin_point":{"x":1,"y":2},"primary":false,"refresh_rate":{"type":"double","value":119.9554},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"rational","value":{"denominator":100,"numerator":175}}}},)"
-                                                                                 R"({"device_id":"ID_2","display_name":"NAME_2","edid":{"manufacturer_id":"","product_code":"","serial_number":0},"friendly_name":"FU_NAME_2","info":{"hdr_state":"Disabled","origin_point":{"x":0,"y":0},"primary":true,"refresh_rate":{"type":"rational","value":{"denominator":10000,"numerator":1199554}},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"double","value":1.75}}},)"
-                                                                                 R"({"device_id":"","display_name":"","edid":null,"friendly_name":"","info":null}])");
+  executeTestCase(display_device::EnumeratedDeviceList {item_1, item_2, item_3}, R"([{"device_id":"ID_1","display_name":"NAME_2","edid":null,"friendly_name":"FU_NAME_3","info":{"hdr_state":"Enabled","origin_point":{"x":1,"y":2},"primary":false,"refresh_rate":{"type":"double","value":119.9554},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"rational","value":{"denominator":100,"numerator":175}}},"is_internal":false},)"
+                                                                                 R"({"device_id":"ID_2","display_name":"NAME_2","edid":{"manufacturer_id":"","product_code":"","serial_number":0},"friendly_name":"FU_NAME_2","info":{"hdr_state":"Disabled","origin_point":{"x":0,"y":0},"primary":true,"refresh_rate":{"type":"rational","value":{"denominator":10000,"numerator":1199554}},"resolution":{"height":1080,"width":1920},"resolution_scale":{"type":"double","value":1.75}},"is_internal":false},)"
+                                                                                 R"({"device_id":"","display_name":"","edid":null,"friendly_name":"","info":null,"is_internal":false}])");
   executeInvalidJsonTestCase<display_device::EnumeratedDeviceList>();
   executeFromJsonFailureTestCase<display_device::EnumeratedDeviceList>(R"([{}])");
   executeToJsonFailureTestCase(display_device::EnumeratedDeviceList {display_device::EnumeratedDevice {.m_device_id = "ID\xC2"}});
@@ -124,4 +124,12 @@ TEST_F_S(Bool) {
   executeTestCase(false, R"(false)");
   executeInvalidJsonTestCase<bool>();
   executeFromJsonFailureTestCase<bool>(R"("not-bool")");
+}
+
+TEST_F_S(EnumeratedDeviceInternalPanelMetadata) {
+  display_device::EnumeratedDevice device {.m_is_internal = true};
+  EXPECT_TRUE(display_device::fromJson(R"({"device_id":"","display_name":"","edid":null,"friendly_name":"","info":null})", device));
+  EXPECT_FALSE(device.m_is_internal);
+  device.m_is_internal = true;
+  executeTestCase(device, R"({"device_id":"","display_name":"","edid":null,"friendly_name":"","info":null,"is_internal":true})");
 }

--- a/tests/unit/windows/test_settings_manager_revert.cpp
+++ b/tests/unit/windows/test_settings_manager_revert.cpp
@@ -529,6 +529,7 @@ TEST_F_S_MOCKED(FailedToSetInitialTopology) {
     .WillOnce(Return(false))
     .RetiresOnSaturation();
 
+  EXPECT_CALL(*m_dd_api, enumAvailableDevices()).WillOnce(Return(CURRENT_DEVICES));
   expectedDefaultTopologyGuardCall(sequence);
   expectedHdrWorkaroundCalls(sequence);
 

--- a/tests/unit/windows/test_settings_manager_undock.cpp
+++ b/tests/unit/windows/test_settings_manager_undock.cpp
@@ -1,0 +1,203 @@
+#include "display_device/windows/settings_manager.h"
+#include "display_device/windows/settings_utils.h"
+#include "fixtures/fixtures.h"
+#include "fixtures/mock_audio_context.h"
+#include "fixtures/mock_settings_persistence.h"
+#include "utils/helpers.h"
+#include "utils/mock_win_display_device.h"
+
+#include <algorithm>
+
+namespace {
+  using namespace display_device;
+  using ::testing::_;
+  using ::testing::NiceMock;
+  using ::testing::Return;
+
+  class UndockRecovery: public BaseTest {
+  protected:
+    ActiveTopology active {{"stream"}};
+    EnumeratedDeviceList devices {{.m_device_id = "stream"}};
+    SingleDisplayConfigState state {{{{"dock"}}, {"dock"}}, {{{"stream"}}, {}, {}, {}}};
+    std::vector<ActiveTopology> writes;
+    bool fail_activation {};
+    bool lie_about_activation {};
+    bool fail_cleanup {};
+    bool fail_clear {};
+    bool lie_about_cleanup {};
+    int clears {};
+    std::shared_ptr<NiceMock<MockWinDisplayDevice>> api = std::make_shared<NiceMock<MockWinDisplayDevice>>();
+    std::shared_ptr<NiceMock<MockSettingsPersistence>> persistence = std::make_shared<NiceMock<MockSettingsPersistence>>();
+    std::shared_ptr<NiceMock<MockAudioContext>> audio = std::make_shared<NiceMock<MockAudioContext>>();
+    std::unique_ptr<SettingsManager> manager;
+
+    void init() {
+      ON_CALL(*api, isApiAccessAvailable()).WillByDefault(Return(true));
+      ON_CALL(*api, enumAvailableDevices()).WillByDefault([&] {
+        return devices;
+      });
+      ON_CALL(*api, getCurrentTopology()).WillByDefault([&] {
+        return active;
+      });
+      ON_CALL(*api, isTopologyValid(_)).WillByDefault([](const auto &t) {
+        return !t.empty();
+      });
+      ON_CALL(*api, isTopologyTheSame(_, _)).WillByDefault([](const auto &a, const auto &b) {
+        return win_utils::flattenTopology(a) == win_utils::flattenTopology(b);
+      });
+      ON_CALL(*api, setTopology(_)).WillByDefault([&](const ActiveTopology &target) {
+        writes.push_back(target);
+        const auto ids = win_utils::flattenTopology(target);
+        if (ids.empty()) {
+          ADD_FAILURE() << "Attempted to blank every output";
+          return false;
+        }
+        for (const auto &id : ids) {
+          if (std::ranges::none_of(devices, [&](const auto &d) {
+                return d.m_device_id == id;
+              })) {
+            return false;
+          }
+        }
+        if (fail_activation && ids.contains("panel")) {
+          return false;
+        }
+        if (fail_cleanup && !ids.contains("stream")) {
+          return false;
+        }
+        if (!lie_about_activation && !(lie_about_cleanup && !ids.contains("stream"))) {
+          active = target;
+        }
+        return true;
+      });
+      ON_CALL(*persistence, load()).WillByDefault([&] {
+        return serializeState(state);
+      });
+      ON_CALL(*persistence, store(_)).WillByDefault(Return(true));
+      ON_CALL(*persistence, clear()).WillByDefault([&] {
+        if (fail_clear) {
+          return false;
+        }
+        ++clears;
+        return true;
+      });
+      manager = std::make_unique<SettingsManager>(api, audio, std::make_unique<PersistentState>(persistence), WinWorkarounds {});
+    }
+
+    void openLid() {
+      devices.push_back({.m_device_id = "panel", .m_is_internal = true});
+    }
+  };
+}  // namespace
+
+TEST_F(UndockRecovery, ClosedLidRetainsRecoveryUntilPanelAppears) {
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::SwitchingTopologyFailed);
+  EXPECT_EQ(clears, 0);
+  EXPECT_EQ(active, (ActiveTopology {{"stream"}}));
+  openLid();
+  writes.clear();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::Ok);
+  EXPECT_EQ(active, (ActiveTopology {{"panel"}}));
+  ASSERT_GE(writes.size(), 3u);
+  EXPECT_EQ(win_utils::flattenTopology(writes[writes.size() - 2]), (StringSet {"panel", "stream"}));
+  EXPECT_EQ(clears, 1);
+  writes.clear();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::Ok);
+  EXPECT_TRUE(writes.empty());
+}
+
+TEST_F(UndockRecovery, RecoverySurvivesControllerRestart) {
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::SwitchingTopologyFailed);
+  manager.reset();
+  openLid();
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::Ok);
+  EXPECT_EQ(active, (ActiveTopology {{"panel"}}));
+}
+
+TEST_F(UndockRecovery, RedockRestoresOriginalOutput) {
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::SwitchingTopologyFailed);
+  devices.push_back({.m_device_id = "dock"});
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::Ok);
+  EXPECT_EQ(active, (ActiveTopology {{"dock"}}));
+  EXPECT_EQ(clears, 1);
+}
+
+TEST_F(UndockRecovery, PreservesUnrelatedActiveOutput) {
+  openLid();
+  devices.push_back({.m_device_id = "other"});
+  active.push_back({"other"});
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::Ok);
+  EXPECT_EQ(win_utils::flattenTopology(active), (StringSet {"panel", "other"}));
+}
+
+TEST_F(UndockRecovery, RestoresSurvivingOriginalDisplay) {
+  state.m_initial.m_topology.push_back({"survivor"});
+  devices.push_back({.m_device_id = "survivor"});
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::Ok);
+  EXPECT_EQ(active, (ActiveTopology {{"survivor"}}));
+}
+
+TEST_F(UndockRecovery, DoesNotMistakeUnknownOutputForLaptopPanel) {
+  devices.push_back({.m_device_id = "unknown"});
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::SwitchingTopologyFailed);
+  EXPECT_EQ(clears, 0);
+}
+
+TEST_F(UndockRecovery, ActivationFailureDoesNotRemoveStreamingOutput) {
+  openLid();
+  fail_activation = true;
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::SwitchingTopologyFailed);
+  EXPECT_EQ(clears, 0);
+  EXPECT_TRUE(win_utils::flattenTopology(active).contains("stream"));
+}
+
+TEST_F(UndockRecovery, ActivationRequiresReadback) {
+  openLid();
+  lie_about_activation = true;
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::SwitchingTopologyFailed);
+  EXPECT_EQ(clears, 0);
+  for (const auto &target : writes) {
+    if (!win_utils::flattenTopology(target).contains("dock")) {
+      EXPECT_TRUE(win_utils::flattenTopology(target).contains("stream"));
+    }
+  }
+}
+
+TEST_F(UndockRecovery, CleanupFailureRetainsPersistence) {
+  openLid();
+  fail_cleanup = true;
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::SwitchingTopologyFailed);
+  EXPECT_EQ(clears, 0);
+  EXPECT_TRUE(win_utils::flattenTopology(active).contains("panel"));
+}
+
+TEST_F(UndockRecovery, FailedPersistenceCanRetry) {
+  openLid();
+  fail_clear = true;
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::PersistenceSaveFailed);
+  EXPECT_EQ(clears, 0);
+  fail_clear = false;
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::Ok);
+  EXPECT_EQ(active, (ActiveTopology {{"panel"}}));
+  EXPECT_EQ(clears, 1);
+}
+
+TEST_F(UndockRecovery, CleanupRequiresReadback) {
+  openLid();
+  lie_about_cleanup = true;
+  init();
+  EXPECT_EQ(manager->revertSettings(), SettingsManager::RevertResult::SwitchingTopologyFailed);
+  EXPECT_EQ(clears, 0);
+  EXPECT_TRUE(win_utils::flattenTopology(active).contains("stream"));
+}

--- a/tests/unit/windows/test_settings_manager_undock.cpp
+++ b/tests/unit/windows/test_settings_manager_undock.cpp
@@ -1,3 +1,7 @@
+/**
+ * @file tests/unit/windows/test_settings_manager_undock.cpp
+ * @brief Tests for display recovery across laptop lid and docking changes.
+ */
 #include "display_device/windows/settings_manager.h"
 #include "display_device/windows/settings_utils.h"
 #include "fixtures/fixtures.h"
@@ -15,7 +19,7 @@ namespace {
   using ::testing::Return;
 
   class UndockRecovery: public BaseTest {
-  protected:
+  public:
     ActiveTopology active {{"stream"}};
     EnumeratedDeviceList devices {{.m_device_id = "stream"}};
     SingleDisplayConfigState state {{{{"dock"}}, {"dock"}}, {{{"stream"}}, {}, {}, {}}};
@@ -31,12 +35,44 @@ namespace {
     std::shared_ptr<NiceMock<MockAudioContext>> audio = std::make_shared<NiceMock<MockAudioContext>>();
     std::unique_ptr<SettingsManager> manager;
 
+    /**
+     * @brief Simulate topology writes, including unavailable devices and unreliable API results.
+     * @param target Requested active display groups.
+     * @return Whether the simulated API reports success.
+     */
+    bool applyTopology(const ActiveTopology &target) {
+      writes.push_back(target);
+      const auto ids = win_utils::flattenTopology(target);
+      if (ids.empty()) {
+        ADD_FAILURE() << "Attempted to blank every output";
+        return false;
+      }
+      for (const auto &id : ids) {
+        if (std::ranges::none_of(devices, [&id](const auto &d) {
+              return d.m_device_id == id;
+            })) {
+          return false;
+        }
+      }
+      if (fail_activation && ids.contains("panel")) {
+        return false;
+      }
+      if (fail_cleanup && !ids.contains("stream")) {
+        return false;
+      }
+      if (!lie_about_activation && !(lie_about_cleanup && !ids.contains("stream"))) {
+        active = target;
+      }
+      return true;
+    }
+
+    /** @brief Connect the stateful display and persistence mocks to the manager. */
     void init() {
       ON_CALL(*api, isApiAccessAvailable()).WillByDefault(Return(true));
-      ON_CALL(*api, enumAvailableDevices()).WillByDefault([&] {
+      ON_CALL(*api, enumAvailableDevices()).WillByDefault([this] {
         return devices;
       });
-      ON_CALL(*api, getCurrentTopology()).WillByDefault([&] {
+      ON_CALL(*api, getCurrentTopology()).WillByDefault([this] {
         return active;
       });
       ON_CALL(*api, isTopologyValid(_)).WillByDefault([](const auto &t) {
@@ -45,36 +81,14 @@ namespace {
       ON_CALL(*api, isTopologyTheSame(_, _)).WillByDefault([](const auto &a, const auto &b) {
         return win_utils::flattenTopology(a) == win_utils::flattenTopology(b);
       });
-      ON_CALL(*api, setTopology(_)).WillByDefault([&](const ActiveTopology &target) {
-        writes.push_back(target);
-        const auto ids = win_utils::flattenTopology(target);
-        if (ids.empty()) {
-          ADD_FAILURE() << "Attempted to blank every output";
-          return false;
-        }
-        for (const auto &id : ids) {
-          if (std::ranges::none_of(devices, [&](const auto &d) {
-                return d.m_device_id == id;
-              })) {
-            return false;
-          }
-        }
-        if (fail_activation && ids.contains("panel")) {
-          return false;
-        }
-        if (fail_cleanup && !ids.contains("stream")) {
-          return false;
-        }
-        if (!lie_about_activation && !(lie_about_cleanup && !ids.contains("stream"))) {
-          active = target;
-        }
-        return true;
+      ON_CALL(*api, setTopology(_)).WillByDefault([this](const ActiveTopology &target) {
+        return applyTopology(target);
       });
-      ON_CALL(*persistence, load()).WillByDefault([&] {
+      ON_CALL(*persistence, load()).WillByDefault([this] {
         return serializeState(state);
       });
       ON_CALL(*persistence, store(_)).WillByDefault(Return(true));
-      ON_CALL(*persistence, clear()).WillByDefault([&] {
+      ON_CALL(*persistence, clear()).WillByDefault([this] {
         if (fail_clear) {
           return false;
         }
@@ -84,6 +98,7 @@ namespace {
       manager = std::make_unique<SettingsManager>(api, audio, std::make_unique<PersistentState>(persistence), WinWorkarounds {});
     }
 
+    /** @brief Make the built-in panel available after opening the lid. */
     void openLid() {
       devices.push_back({.m_device_id = "panel", .m_is_internal = true});
     }

--- a/tests/unit/windows/test_win_display_device_general.cpp
+++ b/tests/unit/windows/test_win_display_device_general.cpp
@@ -151,6 +151,9 @@ TEST_F_S_MOCKED(EnumAvailableDevices) {
   const auto pam_active_and_inactive {[]() {
     auto pam {ut_consts::PAM_3_ACTIVE};
     pam->m_paths.at(0).targetInfo.refreshRate.Denominator = 0;
+    pam->m_paths.at(0).targetInfo.outputTechnology = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EMBEDDED;
+    pam->m_paths.at(1).targetInfo.outputTechnology = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INDIRECT_WIRED;
+    pam->m_paths.at(2).targetInfo.outputTechnology = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_LVDS;
     pam->m_paths.at(2).flags &= ~DISPLAYCONFIG_PATH_ACTIVE;
     return pam;
   }()};
@@ -179,7 +182,8 @@ TEST_F_S_MOCKED(EnumAvailableDevices) {
        true,
        {0, 0},
        std::nullopt
-     }},
+     },
+     true},
     {"DeviceId2",
      "DisplayName2",
      "FriendlyName2",
@@ -196,7 +200,8 @@ TEST_F_S_MOCKED(EnumAvailableDevices) {
      "",
      "FriendlyName3",
      std::nullopt,
-     std::nullopt}
+     std::nullopt,
+     true}
   };
   EXPECT_EQ(m_win_dd.enumAvailableDevices(), expected_list);
 }

--- a/tests/unit/windows/test_win_display_device_modes.cpp
+++ b/tests/unit/windows/test_win_display_device_modes.cpp
@@ -102,8 +102,8 @@ namespace {
       }
     }
 
-    void setupExpectedDisplayModeUndo(const std::optional<display_device::PathAndModeData> &pam_initial) const {
-      EXPECT_CALL(*m_layer, setDisplayConfig(pam_initial->m_paths, pam_initial->m_modes, UNDO_FLAGS))
+    void setupExpectedDisplayModeUndo(const std::optional<display_device::PathAndModeData> &pam_initial, const UINT32 flags = UNDO_FLAGS) const {
+      EXPECT_CALL(*m_layer, setDisplayConfig(pam_initial->m_paths, pam_initial->m_modes, flags))
         .Times(1)
         .WillOnce(Return(ERROR_SUCCESS))
         .RetiresOnSaturation();
@@ -112,6 +112,16 @@ namespace {
     std::shared_ptr<StrictMock<display_device::MockWinApiLayer>> m_layer {std::make_shared<StrictMock<display_device::MockWinApiLayer>>()};
     display_device::WinDisplayDevice m_win_dd {m_layer};
   };
+
+  /** @brief Exercise saved and session-only display changes with the same assertions. */
+  class WinDisplayDeviceModesPersistence: public WinDisplayDeviceModesMocked, public ::testing::WithParamInterface<bool> {
+  public:
+    WinDisplayDeviceModesPersistence() {
+      m_win_dd = display_device::WinDisplayDevice {m_layer, GetParam()};
+    }
+  };
+
+  INSTANTIATE_TEST_SUITE_P(SaveToDatabase, WinDisplayDeviceModesPersistence, ::testing::Bool());
 
   // Specialized TEST macro(s) for this test file
 #define TEST_F_S(...) DD_MAKE_TEST(TEST_F, WinDisplayDeviceModes, __VA_ARGS__)
@@ -339,7 +349,7 @@ TEST_F_S_MOCKED(SetDisplayModes, Relaxed) {
   EXPECT_TRUE(m_win_dd.setDisplayModes(new_modes));
 }
 
-TEST_F_S_MOCKED(SetDisplayModes, Strict) {
+TEST_P(WinDisplayDeviceModesPersistence, Strict) {
   const auto new_modes {makeStrictDisplayModes()};
   const auto &pam_initial {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
   const auto pam_submitted {applyExpectedModesOntoInput(pam_initial, new_modes, {"DeviceId4"})};
@@ -349,13 +359,13 @@ TEST_F_S_MOCKED(SetDisplayModes, Strict) {
 
   // Relaxed try
   {
-    setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, RELAXED_FLAGS);
+    setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, (GetParam() ? RELAXED_FLAGS : RELAXED_FLAGS & ~SDC_SAVE_TO_DATABASE));
     setupExpectedGetCurrentDisplayModesCall(sequence, pam_initial);
   }
 
   // Strict try
   {
-    setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, STRICT_FLAGS);
+    setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, (GetParam() ? STRICT_FLAGS : STRICT_FLAGS & ~SDC_SAVE_TO_DATABASE));
     setupExpectedGetCurrentDisplayModesCall(sequence, pam_submitted);
   }
 
@@ -517,7 +527,7 @@ TEST_F_S_MOCKED(SetDisplayModes, Relaxed, FailedToGetCurrentDisplayModes) {
   EXPECT_FALSE(m_win_dd.setDisplayModes(new_modes));
 }
 
-TEST_F_S_MOCKED(SetDisplayModes, Strict, FailedToSetDisplayConfig) {
+TEST_P(WinDisplayDeviceModesPersistence, StrictFailureRestoresOriginalModes) {
   const auto new_modes {makeStrictDisplayModes()};
   const auto &pam_initial {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
   const auto pam_submitted {applyExpectedModesOntoInput(pam_initial, new_modes, {"DeviceId4"})};
@@ -527,14 +537,14 @@ TEST_F_S_MOCKED(SetDisplayModes, Strict, FailedToSetDisplayConfig) {
 
   // Relaxed try
   {
-    setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, RELAXED_FLAGS);
+    setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, (GetParam() ? RELAXED_FLAGS : RELAXED_FLAGS & ~SDC_SAVE_TO_DATABASE));
     setupExpectedGetCurrentDisplayModesCall(sequence, pam_initial);
   }
 
   // Strict try
   {
-    setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, STRICT_FLAGS, ERROR_ACCESS_DENIED);
-    setupExpectedDisplayModeUndo(pam_initial);
+    setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, (GetParam() ? STRICT_FLAGS : STRICT_FLAGS & ~SDC_SAVE_TO_DATABASE), ERROR_ACCESS_DENIED);
+    setupExpectedDisplayModeUndo(pam_initial, GetParam() ? UNDO_FLAGS : UNDO_FLAGS & ~SDC_SAVE_TO_DATABASE);
   }
 
   EXPECT_FALSE(m_win_dd.setDisplayModes(new_modes));
@@ -586,130 +596,6 @@ TEST_F_S_MOCKED(SetDisplayModes, Strict, ModesDidNotChange) {
     setupExpectedDisplayModeSubmitAttempt(sequence, pam_initial, pam_submitted, STRICT_FLAGS);
     setupExpectedGetCurrentDisplayModesCall(sequence, pam_initial);
     setupExpectedDisplayModeUndo(pam_initial);
-  }
-
-  EXPECT_FALSE(m_win_dd.setDisplayModes(new_modes));
-}
-
-// Session-only CCD changes must never replace the saved docking layout.
-TEST_F_S_MOCKED(SetDisplayModes, Strict, Temporary) {
-  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
-  const display_device::DeviceDisplayModeMap new_modes {
-    {"DeviceId1", {1920, 1080, {120, 10}}},
-    {"DeviceId2", {1000, 2160, {119995, 100}}},
-    {"DeviceId3", {1000, 1000, {90, 1}}},
-    {"DeviceId4", {3840, 2160, {90, 1}}},
-  };
-
-  const auto pam_initial {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
-  const auto pam_submitted {applyExpectedModesOntoInput(pam_initial, new_modes, {"DeviceId4"})};
-
-  InSequence sequence;
-  setupExpectedGetAllDeviceIdsCall(sequence);
-  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::All))
-    .Times(1)
-    .WillOnce(Return(pam_initial))
-    .RetiresOnSaturation();
-
-  // Relaxed try
-  {
-    EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
-      .Times(1)
-      .WillOnce(Return(pam_initial))
-      .RetiresOnSaturation();
-    setupExpectedGetActivePathCall(1, sequence);
-    setupExpectedGetActivePathCall(2, sequence);
-    setupExpectedGetActivePathCall(3, sequence);
-    setupExpectedGetActivePathCall(4, sequence);
-
-    EXPECT_CALL(*m_layer, setDisplayConfig(pam_submitted->m_paths, pam_submitted->m_modes, (RELAXED_FLAGS & ~SDC_SAVE_TO_DATABASE)))
-      .Times(1)
-      .WillOnce(Return(ERROR_SUCCESS))
-      .RetiresOnSaturation();
-    setupExpectedGetCurrentDisplayModesCall(sequence, pam_initial);
-  }
-
-  // Strict try
-  {
-    EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
-      .Times(1)
-      .WillOnce(Return(pam_initial))
-      .RetiresOnSaturation();
-    setupExpectedGetActivePathCall(1, sequence);
-    setupExpectedGetActivePathCall(2, sequence);
-    setupExpectedGetActivePathCall(3, sequence);
-    setupExpectedGetActivePathCall(4, sequence);
-
-    EXPECT_CALL(*m_layer, setDisplayConfig(pam_submitted->m_paths, pam_submitted->m_modes, (STRICT_FLAGS & ~SDC_SAVE_TO_DATABASE)))
-      .Times(1)
-      .WillOnce(Return(ERROR_SUCCESS))
-      .RetiresOnSaturation();
-    setupExpectedGetCurrentDisplayModesCall(sequence, pam_submitted);
-  }
-
-  EXPECT_TRUE(m_win_dd.setDisplayModes(new_modes));
-}
-
-TEST_F_S_MOCKED(SetDisplayModes, Strict, FailedToSetDisplayConfig, Temporary) {
-  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
-  const display_device::DeviceDisplayModeMap new_modes {
-    {"DeviceId1", {1920, 1080, {120, 10}}},
-    {"DeviceId2", {1000, 2160, {119995, 100}}},
-    {"DeviceId3", {1000, 1000, {90, 1}}},
-    {"DeviceId4", {3840, 2160, {90, 1}}},
-  };
-
-  const auto pam_initial {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
-  const auto pam_submitted {applyExpectedModesOntoInput(pam_initial, new_modes, {"DeviceId4"})};
-
-  InSequence sequence;
-  setupExpectedGetAllDeviceIdsCall(sequence);
-  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::All))
-    .Times(1)
-    .WillOnce(Return(pam_initial))
-    .RetiresOnSaturation();
-
-  // Relaxed try
-  {
-    EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
-      .Times(1)
-      .WillOnce(Return(pam_initial))
-      .RetiresOnSaturation();
-    setupExpectedGetActivePathCall(1, sequence);
-    setupExpectedGetActivePathCall(2, sequence);
-    setupExpectedGetActivePathCall(3, sequence);
-    setupExpectedGetActivePathCall(4, sequence);
-
-    EXPECT_CALL(*m_layer, setDisplayConfig(pam_submitted->m_paths, pam_submitted->m_modes, (RELAXED_FLAGS & ~SDC_SAVE_TO_DATABASE)))
-      .Times(1)
-      .WillOnce(Return(ERROR_SUCCESS))
-      .RetiresOnSaturation();
-    setupExpectedGetCurrentDisplayModesCall(sequence, pam_initial);
-  }
-
-  // Strict try
-  {
-    EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
-      .Times(1)
-      .WillOnce(Return(pam_initial))
-      .RetiresOnSaturation();
-    setupExpectedGetActivePathCall(1, sequence);
-    setupExpectedGetActivePathCall(2, sequence);
-    setupExpectedGetActivePathCall(3, sequence);
-    setupExpectedGetActivePathCall(4, sequence);
-
-    EXPECT_CALL(*m_layer, setDisplayConfig(pam_submitted->m_paths, pam_submitted->m_modes, (STRICT_FLAGS & ~SDC_SAVE_TO_DATABASE)))
-      .Times(1)
-      .WillOnce(Return(ERROR_ACCESS_DENIED))
-      .RetiresOnSaturation();
-    EXPECT_CALL(*m_layer, getErrorString(ERROR_ACCESS_DENIED))
-      .Times(1)
-      .WillRepeatedly(Return("ErrorDesc"))
-      .RetiresOnSaturation();
-    EXPECT_CALL(*m_layer, setDisplayConfig(pam_initial->m_paths, pam_initial->m_modes, (UNDO_FLAGS & ~SDC_SAVE_TO_DATABASE)))
-      .Times(1)
-      .WillOnce(Return(ERROR_SUCCESS))
-      .RetiresOnSaturation();
   }
 
   EXPECT_FALSE(m_win_dd.setDisplayModes(new_modes));

--- a/tests/unit/windows/test_win_display_device_modes.cpp
+++ b/tests/unit/windows/test_win_display_device_modes.cpp
@@ -590,3 +590,127 @@ TEST_F_S_MOCKED(SetDisplayModes, Strict, ModesDidNotChange) {
 
   EXPECT_FALSE(m_win_dd.setDisplayModes(new_modes));
 }
+
+// Session-only CCD changes must never replace the saved docking layout.
+TEST_F_S_MOCKED(SetDisplayModes, Strict, Temporary) {
+  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
+  const display_device::DeviceDisplayModeMap new_modes {
+    {"DeviceId1", {1920, 1080, {120, 10}}},
+    {"DeviceId2", {1000, 2160, {119995, 100}}},
+    {"DeviceId3", {1000, 1000, {90, 1}}},
+    {"DeviceId4", {3840, 2160, {90, 1}}},
+  };
+
+  const auto pam_initial {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
+  const auto pam_submitted {applyExpectedModesOntoInput(pam_initial, new_modes, {"DeviceId4"})};
+
+  InSequence sequence;
+  setupExpectedGetAllDeviceIdsCall(sequence);
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::All))
+    .Times(1)
+    .WillOnce(Return(pam_initial))
+    .RetiresOnSaturation();
+
+  // Relaxed try
+  {
+    EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+      .Times(1)
+      .WillOnce(Return(pam_initial))
+      .RetiresOnSaturation();
+    setupExpectedGetActivePathCall(1, sequence);
+    setupExpectedGetActivePathCall(2, sequence);
+    setupExpectedGetActivePathCall(3, sequence);
+    setupExpectedGetActivePathCall(4, sequence);
+
+    EXPECT_CALL(*m_layer, setDisplayConfig(pam_submitted->m_paths, pam_submitted->m_modes, (RELAXED_FLAGS & ~SDC_SAVE_TO_DATABASE)))
+      .Times(1)
+      .WillOnce(Return(ERROR_SUCCESS))
+      .RetiresOnSaturation();
+    setupExpectedGetCurrentDisplayModesCall(sequence, pam_initial);
+  }
+
+  // Strict try
+  {
+    EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+      .Times(1)
+      .WillOnce(Return(pam_initial))
+      .RetiresOnSaturation();
+    setupExpectedGetActivePathCall(1, sequence);
+    setupExpectedGetActivePathCall(2, sequence);
+    setupExpectedGetActivePathCall(3, sequence);
+    setupExpectedGetActivePathCall(4, sequence);
+
+    EXPECT_CALL(*m_layer, setDisplayConfig(pam_submitted->m_paths, pam_submitted->m_modes, (STRICT_FLAGS & ~SDC_SAVE_TO_DATABASE)))
+      .Times(1)
+      .WillOnce(Return(ERROR_SUCCESS))
+      .RetiresOnSaturation();
+    setupExpectedGetCurrentDisplayModesCall(sequence, pam_submitted);
+  }
+
+  EXPECT_TRUE(m_win_dd.setDisplayModes(new_modes));
+}
+
+TEST_F_S_MOCKED(SetDisplayModes, Strict, FailedToSetDisplayConfig, Temporary) {
+  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
+  const display_device::DeviceDisplayModeMap new_modes {
+    {"DeviceId1", {1920, 1080, {120, 10}}},
+    {"DeviceId2", {1000, 2160, {119995, 100}}},
+    {"DeviceId3", {1000, 1000, {90, 1}}},
+    {"DeviceId4", {3840, 2160, {90, 1}}},
+  };
+
+  const auto pam_initial {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
+  const auto pam_submitted {applyExpectedModesOntoInput(pam_initial, new_modes, {"DeviceId4"})};
+
+  InSequence sequence;
+  setupExpectedGetAllDeviceIdsCall(sequence);
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::All))
+    .Times(1)
+    .WillOnce(Return(pam_initial))
+    .RetiresOnSaturation();
+
+  // Relaxed try
+  {
+    EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+      .Times(1)
+      .WillOnce(Return(pam_initial))
+      .RetiresOnSaturation();
+    setupExpectedGetActivePathCall(1, sequence);
+    setupExpectedGetActivePathCall(2, sequence);
+    setupExpectedGetActivePathCall(3, sequence);
+    setupExpectedGetActivePathCall(4, sequence);
+
+    EXPECT_CALL(*m_layer, setDisplayConfig(pam_submitted->m_paths, pam_submitted->m_modes, (RELAXED_FLAGS & ~SDC_SAVE_TO_DATABASE)))
+      .Times(1)
+      .WillOnce(Return(ERROR_SUCCESS))
+      .RetiresOnSaturation();
+    setupExpectedGetCurrentDisplayModesCall(sequence, pam_initial);
+  }
+
+  // Strict try
+  {
+    EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+      .Times(1)
+      .WillOnce(Return(pam_initial))
+      .RetiresOnSaturation();
+    setupExpectedGetActivePathCall(1, sequence);
+    setupExpectedGetActivePathCall(2, sequence);
+    setupExpectedGetActivePathCall(3, sequence);
+    setupExpectedGetActivePathCall(4, sequence);
+
+    EXPECT_CALL(*m_layer, setDisplayConfig(pam_submitted->m_paths, pam_submitted->m_modes, (STRICT_FLAGS & ~SDC_SAVE_TO_DATABASE)))
+      .Times(1)
+      .WillOnce(Return(ERROR_ACCESS_DENIED))
+      .RetiresOnSaturation();
+    EXPECT_CALL(*m_layer, getErrorString(ERROR_ACCESS_DENIED))
+      .Times(1)
+      .WillRepeatedly(Return("ErrorDesc"))
+      .RetiresOnSaturation();
+    EXPECT_CALL(*m_layer, setDisplayConfig(pam_initial->m_paths, pam_initial->m_modes, (UNDO_FLAGS & ~SDC_SAVE_TO_DATABASE)))
+      .Times(1)
+      .WillOnce(Return(ERROR_SUCCESS))
+      .RetiresOnSaturation();
+  }
+
+  EXPECT_FALSE(m_win_dd.setDisplayModes(new_modes));
+}

--- a/tests/unit/windows/test_win_display_device_primary.cpp
+++ b/tests/unit/windows/test_win_display_device_primary.cpp
@@ -317,3 +317,35 @@ TEST_F_S_MOCKED(SetAsPrimary, FailedToSetDisplayConfig) {
 
   EXPECT_FALSE(m_win_dd.setAsPrimary("DeviceId4"));
 }
+
+// Session-only CCD changes must never replace the saved docking layout.
+TEST_F_S_MOCKED(SetAsPrimary, NonDuplicatePrimaryDeviceSet, Temporary) {
+  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
+  const auto initial_pam {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
+
+  auto origin_point {initial_pam->m_modes.at(initial_pam->m_paths.at(3).sourceInfo.sourceModeInfoIdx).sourceMode.position};
+  auto expected_pam {initial_pam};
+  shiftModeBy(expected_pam, 0, origin_point);
+  shiftModeBy(expected_pam, 1, origin_point);
+  shiftModeBy(expected_pam, 2, origin_point);
+  shiftModeBy(expected_pam, 3, origin_point);
+
+  InSequence sequence;
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(initial_pam));
+  setupExpectedGetActivePathCall(4, sequence);
+  for (int i = 1; i <= 4; ++i) {
+    EXPECT_CALL(*m_layer, getDeviceId(_))
+      .Times(1)
+      .WillOnce(Return("DeviceId" + std::to_string(i)))
+      .RetiresOnSaturation();
+  }
+
+  EXPECT_CALL(*m_layer, setDisplayConfig(expected_pam->m_paths, expected_pam->m_modes, (FLAGS & ~SDC_SAVE_TO_DATABASE)))
+    .Times(1)
+    .WillOnce(Return(ERROR_SUCCESS))
+    .RetiresOnSaturation();
+
+  EXPECT_TRUE(m_win_dd.setAsPrimary("DeviceId4"));
+}

--- a/tests/unit/windows/test_win_display_device_primary.cpp
+++ b/tests/unit/windows/test_win_display_device_primary.cpp
@@ -39,14 +39,14 @@ namespace {
       expectActivePathLookup(m_layer, id_number);
     }
 
-    void setupExpectedSetAsPrimaryConfigCall(InSequence &sequence /* To ensure that sequence is created outside this scope */, const std::optional<display_device::PathAndModeData> &initial_pam, const std::optional<display_device::PathAndModeData> &expected_pam, const int active_path_id, const LONG result = ERROR_SUCCESS) const {
+    void setupExpectedSetAsPrimaryConfigCall(InSequence &sequence /* To ensure that sequence is created outside this scope */, const std::optional<display_device::PathAndModeData> &initial_pam, const std::optional<display_device::PathAndModeData> &expected_pam, const int active_path_id, const LONG result = ERROR_SUCCESS, const UINT32 flags = FLAGS) const {
       EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
         .Times(1)
         .WillOnce(Return(initial_pam));
       setupExpectedGetActivePathCall(active_path_id, sequence);
       expectDeviceIdLookups(m_layer, 4);
 
-      EXPECT_CALL(*m_layer, setDisplayConfig(expected_pam->m_paths, expected_pam->m_modes, FLAGS))
+      EXPECT_CALL(*m_layer, setDisplayConfig(expected_pam->m_paths, expected_pam->m_modes, flags))
         .Times(1)
         .WillOnce(Return(result))
         .RetiresOnSaturation();
@@ -62,6 +62,16 @@ namespace {
     std::shared_ptr<StrictMock<display_device::MockWinApiLayer>> m_layer {std::make_shared<StrictMock<display_device::MockWinApiLayer>>()};
     display_device::WinDisplayDevice m_win_dd {m_layer};
   };
+
+  /** @brief Exercise saved and session-only display changes with the same assertions. */
+  class WinDisplayDevicePrimaryPersistence: public WinDisplayDevicePrimaryMocked, public ::testing::WithParamInterface<bool> {
+  public:
+    WinDisplayDevicePrimaryPersistence() {
+      m_win_dd = display_device::WinDisplayDevice {m_layer, GetParam()};
+    }
+  };
+
+  INSTANTIATE_TEST_SUITE_P(SaveToDatabase, WinDisplayDevicePrimaryPersistence, ::testing::Bool());
 
   // Specialized TEST macro(s) for this test file
 #define TEST_F_S(...) DD_MAKE_TEST(TEST_F, WinDisplayDevicePrimary, __VA_ARGS__)
@@ -221,12 +231,12 @@ TEST_F_S_MOCKED(SetAsPrimary, DuplicatePrimaryDevicesSet) {
   EXPECT_TRUE(m_win_dd.setAsPrimary("DeviceId2"));
 }
 
-TEST_F_S_MOCKED(SetAsPrimary, NonDuplicatePrimaryDeviceSet) {
+TEST_P(WinDisplayDevicePrimaryPersistence, NonDuplicatePrimaryDeviceSet) {
   const auto &initial_pam {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
   const auto expected_pam {makeShiftedPrimaryPam(initial_pam, 3, {0, 1, 2, 3})};
 
   InSequence sequence;
-  setupExpectedSetAsPrimaryConfigCall(sequence, initial_pam, expected_pam, 4);
+  setupExpectedSetAsPrimaryConfigCall(sequence, initial_pam, expected_pam, 4, ERROR_SUCCESS, GetParam() ? FLAGS : FLAGS & ~SDC_SAVE_TO_DATABASE);
 
   EXPECT_TRUE(m_win_dd.setAsPrimary("DeviceId4"));
 }
@@ -316,36 +326,4 @@ TEST_F_S_MOCKED(SetAsPrimary, FailedToSetDisplayConfig) {
   setupExpectedSetAsPrimaryConfigCall(sequence, initial_pam, expected_pam, 4, ERROR_ACCESS_DENIED);
 
   EXPECT_FALSE(m_win_dd.setAsPrimary("DeviceId4"));
-}
-
-// Session-only CCD changes must never replace the saved docking layout.
-TEST_F_S_MOCKED(SetAsPrimary, NonDuplicatePrimaryDeviceSet, Temporary) {
-  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
-  const auto initial_pam {ut_consts::PAM_4_ACTIVE_WITH_2_DUPLICATES};
-
-  auto origin_point {initial_pam->m_modes.at(initial_pam->m_paths.at(3).sourceInfo.sourceModeInfoIdx).sourceMode.position};
-  auto expected_pam {initial_pam};
-  shiftModeBy(expected_pam, 0, origin_point);
-  shiftModeBy(expected_pam, 1, origin_point);
-  shiftModeBy(expected_pam, 2, origin_point);
-  shiftModeBy(expected_pam, 3, origin_point);
-
-  InSequence sequence;
-  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
-    .Times(1)
-    .WillOnce(Return(initial_pam));
-  setupExpectedGetActivePathCall(4, sequence);
-  for (int i = 1; i <= 4; ++i) {
-    EXPECT_CALL(*m_layer, getDeviceId(_))
-      .Times(1)
-      .WillOnce(Return("DeviceId" + std::to_string(i)))
-      .RetiresOnSaturation();
-  }
-
-  EXPECT_CALL(*m_layer, setDisplayConfig(expected_pam->m_paths, expected_pam->m_modes, (FLAGS & ~SDC_SAVE_TO_DATABASE)))
-    .Times(1)
-    .WillOnce(Return(ERROR_SUCCESS))
-    .RetiresOnSaturation();
-
-  EXPECT_TRUE(m_win_dd.setAsPrimary("DeviceId4"));
 }

--- a/tests/unit/windows/test_win_display_device_topology.cpp
+++ b/tests/unit/windows/test_win_display_device_topology.cpp
@@ -16,6 +16,9 @@ namespace {
   using ::testing::Return;
   using ::testing::StrictMock;
 
+  const UINT32 SAVED_TOPOLOGY_FLAGS {SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  const UINT32 TEMPORARY_TOPOLOGY_FLAGS {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+
   // Test fixture(s) for this file
   class WinDisplayDeviceTopology: public BaseTest {
   public:
@@ -274,7 +277,7 @@ TEST_P(WinDisplayDeviceTopologyPersistence, SetCurrentTopology) {
   display_device::win_utils::setDesktopIndex(expected_path, std::nullopt);
   display_device::win_utils::setActive(expected_path);
 
-  UINT32 expected_flags {GetParam() ? SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE : SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  UINT32 expected_flags {GetParam() ? SAVED_TOPOLOGY_FLAGS : TEMPORARY_TOPOLOGY_FLAGS};
   EXPECT_CALL(*m_layer, setDisplayConfig(std::vector<DISPLAYCONFIG_PATH_INFO> {expected_path}, std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
     .Times(1)
     .WillOnce(Return(ERROR_SUCCESS));
@@ -379,7 +382,7 @@ TEST_P(WinDisplayDeviceTopologyPersistence, FailedToSetTopology) {
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
 
-  UINT32 expected_flags {GetParam() ? SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE : SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  UINT32 expected_flags {GetParam() ? SAVED_TOPOLOGY_FLAGS : TEMPORARY_TOPOLOGY_FLAGS};
   EXPECT_CALL(*m_layer, setDisplayConfig(getExpectedPathToBeSet(), std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
     .Times(1)
     .WillOnce(Return(ERROR_INVALID_PARAMETER));
@@ -420,7 +423,7 @@ TEST_P(WinDisplayDeviceTopologyPersistence, ReadbackFailureRestoresOriginalTopol
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
 
-  UINT32 expected_flags {GetParam() ? SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE : SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  UINT32 expected_flags {GetParam() ? SAVED_TOPOLOGY_FLAGS : TEMPORARY_TOPOLOGY_FLAGS};
   EXPECT_CALL(*m_layer, setDisplayConfig(getExpectedPathToBeSet(), std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
     .Times(1)
     .WillOnce(Return(ERROR_SUCCESS));

--- a/tests/unit/windows/test_win_display_device_topology.cpp
+++ b/tests/unit/windows/test_win_display_device_topology.cpp
@@ -54,6 +54,16 @@ namespace {
     display_device::WinDisplayDevice m_win_dd {m_layer};
   };
 
+  /** @brief Exercise saved and session-only display changes with the same assertions. */
+  class WinDisplayDeviceTopologyPersistence: public WinDisplayDeviceTopologyMocked, public ::testing::WithParamInterface<bool> {
+  public:
+    WinDisplayDeviceTopologyPersistence() {
+      m_win_dd = display_device::WinDisplayDevice {m_layer, GetParam()};
+    }
+  };
+
+  INSTANTIATE_TEST_SUITE_P(SaveToDatabase, WinDisplayDeviceTopologyPersistence, ::testing::Bool());
+
   // Specialized TEST macro(s) for this test file
 #define TEST_F_S(...) DD_MAKE_TEST(TEST_F, WinDisplayDeviceTopology, __VA_ARGS__)
 #define TEST_F_S_MOCKED(...) DD_MAKE_TEST(TEST_F, WinDisplayDeviceTopologyMocked, __VA_ARGS__)
@@ -252,7 +262,7 @@ TEST_F_S_MOCKED(isTopologyTheSame) {
   EXPECT_EQ(m_win_dd.isTopologyTheSame({{"ID_3"}, {"ID_1", "ID_2"}}, {{"ID_2", "ID_1"}, {"ID_3"}}), true);
 }
 
-TEST_F_S_MOCKED(SetCurrentTopology) {
+TEST_P(WinDisplayDeviceTopologyPersistence, SetCurrentTopology) {
   InSequence sequence;
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
@@ -264,7 +274,7 @@ TEST_F_S_MOCKED(SetCurrentTopology) {
   display_device::win_utils::setDesktopIndex(expected_path, std::nullopt);
   display_device::win_utils::setActive(expected_path);
 
-  UINT32 expected_flags {SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  UINT32 expected_flags {GetParam() ? SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE : SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
   EXPECT_CALL(*m_layer, setDisplayConfig(std::vector<DISPLAYCONFIG_PATH_INFO> {expected_path}, std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
     .Times(1)
     .WillOnce(Return(ERROR_SUCCESS));
@@ -364,12 +374,12 @@ TEST_F_S_MOCKED(SetCurrentTopology, WindowsDoesNotKnowAboutTheTopology, FailedTo
   EXPECT_FALSE(m_win_dd.setTopology({{"DeviceId1"}}));
 }
 
-TEST_F_S_MOCKED(SetCurrentTopology, FailedToSetTopology, NoRecovery) {
+TEST_P(WinDisplayDeviceTopologyPersistence, FailedToSetTopology) {
   InSequence sequence;
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
 
-  UINT32 expected_flags {SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  UINT32 expected_flags {GetParam() ? SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE : SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
   EXPECT_CALL(*m_layer, setDisplayConfig(getExpectedPathToBeSet(), std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
     .Times(1)
     .WillOnce(Return(ERROR_INVALID_PARAMETER));
@@ -405,12 +415,12 @@ TEST_F_S_MOCKED(SetCurrentTopology, TopologyWasSetAccordingToWinApi, CouldNotGet
   EXPECT_FALSE(m_win_dd.setTopology({{"DeviceId1"}}));
 }
 
-TEST_F_S_MOCKED(SetCurrentTopology, TopologyWasSetAccordingToWinApi, WinApiLied) {
+TEST_P(WinDisplayDeviceTopologyPersistence, ReadbackFailureRestoresOriginalTopology) {
   InSequence sequence;
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
 
-  UINT32 expected_flags {SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  UINT32 expected_flags {GetParam() ? SDC_APPLY | SDC_TOPOLOGY_SUPPLIED | SDC_ALLOW_PATH_ORDER_CHANGES | SDC_VIRTUAL_MODE_AWARE : SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
   EXPECT_CALL(*m_layer, setDisplayConfig(getExpectedPathToBeSet(), std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
     .Times(1)
     .WillOnce(Return(ERROR_SUCCESS));
@@ -419,91 +429,10 @@ TEST_F_S_MOCKED(SetCurrentTopology, TopologyWasSetAccordingToWinApi, WinApiLied)
   setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
 
   // Called when doing the undo
-  expected_flags = SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_SAVE_TO_DATABASE | SDC_VIRTUAL_MODE_AWARE;
+  expected_flags = SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_VIRTUAL_MODE_AWARE | (GetParam() ? SDC_SAVE_TO_DATABASE : 0);
   EXPECT_CALL(*m_layer, setDisplayConfig(ut_consts::PAM_3_ACTIVE->m_paths, ut_consts::PAM_3_ACTIVE->m_modes, expected_flags))
     .Times(1)
     .WillOnce(Return(ERROR_SUCCESS));
-
-  EXPECT_FALSE(m_win_dd.setTopology({{"DeviceId1"}}));
-}
-
-// Session-only CCD changes must never replace the saved docking layout.
-TEST_F_S_MOCKED(SetCurrentTopology, Temporary) {
-  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
-  InSequence sequence;
-  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
-  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
-
-  auto expected_path {ut_consts::PAM_3_ACTIVE->m_paths.at(0)};
-  display_device::win_utils::setCloneGroupId(expected_path, 0);
-  display_device::win_utils::setSourceIndex(expected_path, std::nullopt);
-  display_device::win_utils::setTargetIndex(expected_path, std::nullopt);
-  display_device::win_utils::setDesktopIndex(expected_path, std::nullopt);
-  display_device::win_utils::setActive(expected_path);
-
-  UINT32 expected_flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
-  EXPECT_CALL(*m_layer, setDisplayConfig(std::vector<DISPLAYCONFIG_PATH_INFO> {expected_path}, std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
-    .Times(1)
-    .WillOnce(Return(ERROR_SUCCESS));
-
-  // Report only 1 active device
-  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
-    .Times(1)
-    .WillOnce(Return(display_device::PathAndModeData {{ut_consts::PAM_3_ACTIVE->m_paths.at(0)}, {ut_consts::PAM_3_ACTIVE->m_modes.at(0)}}))
-    .RetiresOnSaturation();
-  EXPECT_CALL(*m_layer, getMonitorDevicePath(_))
-    .Times(1)
-    .WillOnce(Return("Path1"))
-    .RetiresOnSaturation();
-  EXPECT_CALL(*m_layer, getDeviceId(_))
-    .Times(1)
-    .WillOnce(Return("DeviceId1"))
-    .RetiresOnSaturation();
-  EXPECT_CALL(*m_layer, getDisplayName(_))
-    .Times(1)
-    .WillOnce(Return("DisplayName1"))
-    .RetiresOnSaturation();
-
-  EXPECT_TRUE(m_win_dd.setTopology({{"DeviceId1"}}));
-}
-
-TEST_F_S_MOCKED(SetCurrentTopology, TopologyWasSetAccordingToWinApi, WinApiLied, Temporary) {
-  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
-  InSequence sequence;
-  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
-  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
-
-  UINT32 expected_flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
-  EXPECT_CALL(*m_layer, setDisplayConfig(getExpectedPathToBeSet(), std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
-    .Times(1)
-    .WillOnce(Return(ERROR_SUCCESS));
-
-  // Called when getting the topology
-  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
-
-  // Called when doing the undo
-  expected_flags = SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_VIRTUAL_MODE_AWARE;
-  EXPECT_CALL(*m_layer, setDisplayConfig(ut_consts::PAM_3_ACTIVE->m_paths, ut_consts::PAM_3_ACTIVE->m_modes, expected_flags))
-    .Times(1)
-    .WillOnce(Return(ERROR_SUCCESS));
-
-  EXPECT_FALSE(m_win_dd.setTopology({{"DeviceId1"}}));
-}
-
-TEST_F_S_MOCKED(SetCurrentTopology, FailedToSetTopology, NoRecovery, Temporary) {
-  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
-  InSequence sequence;
-  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
-  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
-
-  UINT32 expected_flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
-  EXPECT_CALL(*m_layer, setDisplayConfig(getExpectedPathToBeSet(), std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
-    .Times(1)
-    .WillOnce(Return(ERROR_INVALID_PARAMETER));
-
-  EXPECT_CALL(*m_layer, getErrorString(ERROR_INVALID_PARAMETER))
-    .Times(1)
-    .WillRepeatedly(Return("ErrorDesc"));
 
   EXPECT_FALSE(m_win_dd.setTopology({{"DeviceId1"}}));
 }

--- a/tests/unit/windows/test_win_display_device_topology.cpp
+++ b/tests/unit/windows/test_win_display_device_topology.cpp
@@ -426,3 +426,84 @@ TEST_F_S_MOCKED(SetCurrentTopology, TopologyWasSetAccordingToWinApi, WinApiLied)
 
   EXPECT_FALSE(m_win_dd.setTopology({{"DeviceId1"}}));
 }
+
+// Session-only CCD changes must never replace the saved docking layout.
+TEST_F_S_MOCKED(SetCurrentTopology, Temporary) {
+  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
+  InSequence sequence;
+  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
+  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
+
+  auto expected_path {ut_consts::PAM_3_ACTIVE->m_paths.at(0)};
+  display_device::win_utils::setCloneGroupId(expected_path, 0);
+  display_device::win_utils::setSourceIndex(expected_path, std::nullopt);
+  display_device::win_utils::setTargetIndex(expected_path, std::nullopt);
+  display_device::win_utils::setDesktopIndex(expected_path, std::nullopt);
+  display_device::win_utils::setActive(expected_path);
+
+  UINT32 expected_flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  EXPECT_CALL(*m_layer, setDisplayConfig(std::vector<DISPLAYCONFIG_PATH_INFO> {expected_path}, std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
+    .Times(1)
+    .WillOnce(Return(ERROR_SUCCESS));
+
+  // Report only 1 active device
+  EXPECT_CALL(*m_layer, queryDisplayConfig(display_device::QueryType::Active))
+    .Times(1)
+    .WillOnce(Return(display_device::PathAndModeData {{ut_consts::PAM_3_ACTIVE->m_paths.at(0)}, {ut_consts::PAM_3_ACTIVE->m_modes.at(0)}}))
+    .RetiresOnSaturation();
+  EXPECT_CALL(*m_layer, getMonitorDevicePath(_))
+    .Times(1)
+    .WillOnce(Return("Path1"))
+    .RetiresOnSaturation();
+  EXPECT_CALL(*m_layer, getDeviceId(_))
+    .Times(1)
+    .WillOnce(Return("DeviceId1"))
+    .RetiresOnSaturation();
+  EXPECT_CALL(*m_layer, getDisplayName(_))
+    .Times(1)
+    .WillOnce(Return("DisplayName1"))
+    .RetiresOnSaturation();
+
+  EXPECT_TRUE(m_win_dd.setTopology({{"DeviceId1"}}));
+}
+
+TEST_F_S_MOCKED(SetCurrentTopology, TopologyWasSetAccordingToWinApi, WinApiLied, Temporary) {
+  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
+  InSequence sequence;
+  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
+  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
+
+  UINT32 expected_flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  EXPECT_CALL(*m_layer, setDisplayConfig(getExpectedPathToBeSet(), std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
+    .Times(1)
+    .WillOnce(Return(ERROR_SUCCESS));
+
+  // Called when getting the topology
+  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
+
+  // Called when doing the undo
+  expected_flags = SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_VIRTUAL_MODE_AWARE;
+  EXPECT_CALL(*m_layer, setDisplayConfig(ut_consts::PAM_3_ACTIVE->m_paths, ut_consts::PAM_3_ACTIVE->m_modes, expected_flags))
+    .Times(1)
+    .WillOnce(Return(ERROR_SUCCESS));
+
+  EXPECT_FALSE(m_win_dd.setTopology({{"DeviceId1"}}));
+}
+
+TEST_F_S_MOCKED(SetCurrentTopology, FailedToSetTopology, NoRecovery, Temporary) {
+  m_win_dd = display_device::WinDisplayDevice {m_layer, false};
+  InSequence sequence;
+  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::Active, sequence);
+  setupExpectCallFor3ActivePathsAndModes(display_device::QueryType::All, sequence);
+
+  UINT32 expected_flags {SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES | SDC_VIRTUAL_MODE_AWARE};
+  EXPECT_CALL(*m_layer, setDisplayConfig(getExpectedPathToBeSet(), std::vector<DISPLAYCONFIG_MODE_INFO> {}, expected_flags))
+    .Times(1)
+    .WillOnce(Return(ERROR_INVALID_PARAMETER));
+
+  EXPECT_CALL(*m_layer, getErrorString(ERROR_INVALID_PARAMETER))
+    .Times(1)
+    .WillRepeatedly(Return("ErrorDesc"));
+
+  EXPECT_FALSE(m_win_dd.setTopology({{"DeviceId1"}}));
+}


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

I ran into this while using Sunshine with a docked Windows laptop, lid closed, and a virtual display selected with `ensure_only_display`. Unplugging the dock during a stream and then disconnecting leaves the original monitor unavailable. Opening the lid turns the panel on, but the virtual display stays enabled and the old recovery state keeps being retried.

This lets restoration fall back to surviving original displays, or a built-in panel if none remain. It checks that the replacement is active before removing displays enabled by the session, and only clears the recovery state after verifying the final layout. With the lid closed and no physical display available, recovery stays pending.

There was a second part to the same repro: the streaming layout became Windows' saved docked layout, so redocking brought back the virtual display instead of the external monitor. `WinDisplayDevice` now has an optional `save_to_database` argument so callers can make temporary CCD changes. The default stays unchanged. The companion Sunshine change is https://github.com/LizardByte/Sunshine/pull/5625.

Testing:
- 103 common tests pass on the current `master` base.
- 431 tests pass on Windows with the current PR sources, including all 11 undock recovery tests and the saved/temporary display tests. The runner skips 10 hardware-only tests; two existing tests are disabled: [build and report](https://github.com/jdvmi00/libdisplaydevice/actions/runs/34001991285).
- The release-based trial passed the Windows library and Sunshine suites, including the new regression tests. Hardware-only tests were skipped on the runner: [build and reports](https://github.com/jdvmi00/libdisplaydevice/actions/runs/33994095440).
- The original recovery code fails the undock regression in that trial; the patched code passes.
- Tested the full docked stream → unplug with lid closed → disconnect → open lid → redock sequence on the laptop. The panel recovered, the virtual display turned off, recovery state cleared, and redocking restored the external monitor. `QDC_DATABASE_CURRENT` also confirmed the saved docked layout stayed unchanged while streaming.

The hardware trial used Sunshine v2026.516.143833. This PR ports those changes to current `master`. The Windows run above is in my fork; upstream Actions still need maintainer approval to run.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [x] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes

